### PR TITLE
Save object validity for popups and discard on reload if not valid

### DIFF
--- a/OpenSR/scripts/gui/tabs/GalaxyTab.as
+++ b/OpenSR/scripts/gui/tabs/GalaxyTab.as
@@ -255,6 +255,7 @@ class GalaxyTab : Tab {
 			file << pos;
 			bool isFloating = popups[i].objLinked;
 			file << isFloating;
+			file << obj.valid;
 		}
 
 		file << quickbar;
@@ -274,8 +275,10 @@ class GalaxyTab : Tab {
 
 			bool isFloating = false;
 			file >> isFloating;
+			bool valid = true;
+			file >> valid;
 
-			if(obj !is null) {
+			if(obj !is null && obj.valid && valid) {
 				Popup@ pop = pinObject(obj, isFloating);
 				pop.position = pos;
 			}

--- a/OpenSR/scripts/gui/tabs/GalaxyTab.as
+++ b/OpenSR/scripts/gui/tabs/GalaxyTab.as
@@ -278,6 +278,9 @@ class GalaxyTab : Tab {
 			bool valid = true;
 			file >> valid;
 
+			// objects that are invalid can be deserialised as valid, so check
+			// if the object was valid before saving AND is still considered valid
+			// now to cover all possible problems that would lead to a crash
 			if(obj !is null && obj.valid && valid) {
 				Popup@ pop = pinObject(obj, isFloating);
 				pop.position = pos;


### PR DESCRIPTION
I initially tried to just check validity on reload to avoid save file changes, but the game wasn't noticing the object wasn't valid immediately on reload, so the steps given by EngineOfDarkness were still causing the crash