### PR TITLE
Interdict movement fixes

### DIFF
--- a/OpenSR/data/components/mover.txt
+++ b/OpenSR/data/components/mover.txt
@@ -1,0 +1,64 @@
+Object.Mover : components.Mover::Mover {
+local safe:
+	bool get_inFTL() const;
+	bool get_isMoving() const;
+	double get_maxAcceleration() const;
+
+restricted local:
+	vec3d get_moveDestination() const;
+	safe bool get_hasMovePath() const;
+	Object@[] getMovePath() const;
+
+	Object@ getLockedOrbit(bool requireLock = true);
+	Object@ getAroundLockedOrbit();
+	safe bool isLockedOrbit(Object@ at, bool requireLock = true);
+	safe bool hasLockedOrbit(bool requireLock = true);
+
+server:
+	safe double get_ftlSpeed() const;
+	safe quaterniond get_targetRotation() const;
+	void set_ftlSpeed(double value);
+	safe bool get_isColliding() const;
+	safe vec3d get_internalDestination() const;
+	safe vec3d get_computedDestination() const;
+	void set_maxAcceleration(double accel);
+	void set_rotationSpeed(float speed);
+	double moverTick(double time);
+	bool moveTo(vec3d point, int& id, bool doPathing = true, bool enterOrbit = true, bool allowStop = false);
+	bool moveTo(Object& target, int& id, double distance = 0, bool doPathing = true, bool enterOrbit = true);
+	safe bool isOnMoveOrder(int id);
+	bool rotateTo(quaterniond rotation, int& id);
+	void setRotation(quaterniond rotation);
+	bool FTLTo(vec3d point, double speed, int& id);
+	void FTLTo(vec3d point, double speed);
+	void FTLDrop();
+	void stopMoving(bool doPathing = true, bool enterOrbit = true);
+	void clearMovement();
+	void setCombatFacing(quaterniond& rotation);
+	void clearCombatFacing();
+	async relocking void checkOrbitObject(vec3d destPoint);
+	async relocking void createPathTowards(vec3d destPoint, Object@ target = null);
+	async relocking void updatePath();
+	void speedBoost(double amount);
+	void flagPositionUpdate();
+	void modAccelerationBonus(double mod);
+	void forceLockTo(Object@ obj);
+
+	void impulse(vec3d ForceSeconds);
+	void rotate(quaterniond rot);
+
+	safe bool get_leaderLock() const;
+	void set_leaderLock(bool doLock);
+
+	bool get_hasMovePortal();
+	vec3d getMovePortal();
+
+	void set_hasVectorMovement(bool value);
+
+	bool writeMoverDelta(Message& msg) const;
+	void writeMover(Message& msg) const;
+
+shadow:
+	void readMoverDelta(Message& msg);
+	void readMover(Message& msg);
+}

--- a/OpenSR/data/components/mover.txt
+++ b/OpenSR/data/components/mover.txt
@@ -58,6 +58,10 @@ server:
 	bool writeMoverDelta(Message& msg) const;
 	void writeMover(Message& msg) const;
 
+	// CE: InterdictMovement overhaul
+	void addInterdictMovementEffect();
+	void removeInterdictMovementEffect();
+
 shadow:
 	void readMoverDelta(Message& msg);
 	void readMover(Message& msg);

--- a/OpenSR/data/components/statuses.txt
+++ b/OpenSR/data/components/statuses.txt
@@ -1,0 +1,41 @@
+Object.Statuses : components.Statuses::Statuses {
+local:
+	Status@[] getStatusEffects();
+	bool hasStatusEffect(uint typeId);
+
+	safe uint get_statusEffectCount();
+	uint get_statusEffectType(uint index);
+	uint get_statusEffectStacks(uint index);
+	Object@ get_statusEffectOriginObject(uint index);
+	Empire@ get_statusEffectOriginEmpire(uint index);
+
+	uint getStatusStackCount(uint typeId, Object@ originObject = null, Empire@ originEmpire = null);
+	uint getStatusStackCountAny(uint typeId);
+
+server:
+	int addStatus(double timer, uint typeId, Empire@ boundEmpire = null, Region@ boundRegion = null, Empire@ originEmpire = null, Object@ originObject = null);
+	void addStatus(uint typeId, double timer = -1.0, Empire@ boundEmpire = null, Region@ boundRegion = null, Empire@ originEmpire = null, Object@ originObject = null);
+	void removeStatus(int id);
+	bool isStatusInstanceActive(int id);
+	void removeStatusType(uint typeId);
+	void removeStatusInstanceOfType(uint typeId);
+	void removeRegionBoundStatus(Region@ region, uint typeId, double timer = -1.0);
+
+	uint get_statusInstanceCount();
+	uint get_statusInstanceType(uint index);
+	int get_statusInstanceId(uint index);
+
+	void addRandomCondition();
+
+	void changeStatusOwner(Empire@ prevOwner, Empire@ newOwner);
+	void changeStatusRegion(Region@ prevRegion, Region@ newRegion);
+	void statusTick(double time);
+	void destroyStatus();
+
+	void writeStatuses(Message& msg) const;
+	bool writeStatusDelta(Message& msg) const;
+
+shadow:
+	void readStatuses(Message& msg);
+	void readStatusDelta(Message& msg);
+}

--- a/OpenSR/data/components/statuses.txt
+++ b/OpenSR/data/components/statuses.txt
@@ -2,10 +2,14 @@ Object.Statuses : components.Statuses::Statuses {
 local:
 	Status@[] getStatusEffects();
 	bool hasStatusEffect(uint typeId);
+	int getStatusEffectOfType(uint typeId);
 
 	safe uint get_statusEffectCount();
 	uint get_statusEffectType(uint index);
 	uint get_statusEffectStacks(uint index);
+	// NOTE: The status type must be set to showDuration or the server doesn't
+	// use bandwidth sending this to the client and we'll return -2.0 instead
+	double get_statusEffectDuration(uint index);
 	Object@ get_statusEffectOriginObject(uint index);
 	Empire@ get_statusEffectOriginEmpire(uint index);
 

--- a/OpenSR/data/statuses/Entangled.txt
+++ b/OpenSR/data/statuses/Entangled.txt
@@ -4,6 +4,7 @@ Status: Entangled
 	Icon: HexagonSubsystems::6 * #ff8d00
 
 	Unique: True
+	Show Duration: True
 
 	InterdictMovement()
 	DelayFTL()

--- a/OpenSR/data/statuses/Entangled.txt
+++ b/OpenSR/data/statuses/Entangled.txt
@@ -1,0 +1,9 @@
+Status: Entangled
+	Name: #STATUS_ENTANGLED
+	Description: #STATUS_ENTANGLED_DESC
+	Icon: HexagonSubsystems::6 * #ff8d00
+
+	Unique: True
+
+	InterdictMovement()
+	DelayFTL()

--- a/OpenSR/data/statuses/subsystems/ComputerCore.txt
+++ b/OpenSR/data/statuses/subsystems/ComputerCore.txt
@@ -9,5 +9,6 @@ Status: ComputerBoost
 	Description: #STATUS_COMPUTER_BOOST_DESC
 	Icon: QuickbarIcons::6
 	Unique: True
+	Show Duration: True
 
 	ModFleetEffectivenessSubsystem(Sys.EfficiencyBoost)

--- a/OpenSR/data/statuses/subsystems/ComputerCore.txt
+++ b/OpenSR/data/statuses/subsystems/ComputerCore.txt
@@ -1,0 +1,13 @@
+Status: ComputerCore
+	Visible To: Nobody
+	Unique: True
+
+	AddStatusInitialCombat(ComputerBoost, 30)
+
+Status: ComputerBoost
+	Name: #STATUS_COMPUTER_BOOST
+	Description: #STATUS_COMPUTER_BOOST_DESC
+	Icon: QuickbarIcons::6
+	Unique: True
+
+	ModFleetEffectivenessSubsystem(Sys.EfficiencyBoost)

--- a/OpenSR/scripts/definitions/CP_version.as
+++ b/OpenSR/scripts/definitions/CP_version.as
@@ -12,7 +12,7 @@ namespace CommunityPatch {
 		"OSR r70",
 	};
 	const string MOD_NAME = "OpenSR Modpack v1.1.0";
-	const string MOD_REVISION = "244";
+	const string MOD_REVISION = "250";
 	const string MOD_VERSION = MOD_NAME + " (revision " + MOD_REVISION + ") for Star Ruler 2 " + VERSIONS[0] + " (revision " + REVISIONS[0]
 		+ ", currently using " + GAME_VERSION + " " + SCRIPT_VERSION + ")";
 

--- a/OpenSR/scripts/definitions/generic_effects.as
+++ b/OpenSR/scripts/definitions/generic_effects.as
@@ -1915,6 +1915,9 @@ class RepairPerSecond : GenericEffect {
 };
 
 //InterdictMovement()
+// CE: now correctly tells Mover component to handle interdiction and so
+// cannot get out of sync with acceleration being added/removed during the
+// effect uptime.
 // Remove all velocity from an object and prevent it from accelerating.
 class InterdictMovement : GenericEffect {
 	Document doc("The object this effect is active on cannot accelerate in any way.");
@@ -1922,27 +1925,19 @@ class InterdictMovement : GenericEffect {
 #section server
 	void enable(Object& obj, any@ data) const override {
 		if(obj.hasMover) {
-			double acc = obj.maxAcceleration;
-			data.store(acc);
-
 			obj.velocity = vec3d();
 			obj.acceleration = vec3d();
-			obj.maxAcceleration = 0.0;
+			obj.addInterdictMovementEffect();
 		}
 	}
 
 	void tick(Object& obj, any@ data, double time) const override {
-		if(obj.hasMover)
-			obj.maxAcceleration = 0.0;
+		// Do nothing, Mover component handles interdiction now
 	}
 
 	void disable(Object& obj, any@ data) const override {
 		if(obj.hasMover) {
-			if(obj.maxAcceleration == 0.0) {
-				double acc = 0.0;
-				data.retrieve(acc);
-				obj.maxAcceleration = acc;
-			}
+			obj.removeInterdictMovementEffect();
 		}
 	}
 #section all

--- a/OpenSR/scripts/definitions/statuses.as
+++ b/OpenSR/scripts/definitions/statuses.as
@@ -33,6 +33,7 @@ tidy final class StatusType {
 	bool unique = false;
 	bool collapses = false;
 	array<IStatusHook@> hooks;
+	bool showDuration = false;
 
 	string def_conditionType;
 	const PlanetType@ conditionType;
@@ -361,15 +362,15 @@ void parseLine(string& line, StatusType@ type, ReadFile@ file) {
 
 void loadStatus(const string& filename) {
 	ReadFile file(filename, true);
-	
+
 	string key, value;
 	StatusType@ status;
-	
+
 	uint index = 0;
 	while(file++) {
 		key = file.key;
 		value = file.value;
-		
+
 		if(file.fullLine) {
 			string line = file.line;
 			parseLine(line, status, file);
@@ -428,12 +429,15 @@ void loadStatus(const string& filename) {
 			else
 				file.error("Unknown status visibility: "+value);
 		}
+		else if(key.equals_nocase("Show Duration")) {
+			status.showDuration = toBool(value);
+		}
 		else {
 			string line = file.line;
 			parseLine(line, status, file);
 		}
 	}
-	
+
 	if(status !is null)
 		addStatus(status);
 }

--- a/OpenSR/scripts/definitions/statuses.as
+++ b/OpenSR/scripts/definitions/statuses.as
@@ -1,0 +1,460 @@
+#priority init 2000
+import hooks;
+import saving;
+import planet_types;
+import resources;
+
+export StatusType;
+export Status;
+export StatusInstance;
+export getStatusType, getStatusTypeCount;
+export getStatusID;
+export getRandomCondition;
+export StatusVisibility;
+
+enum StatusVisibility {
+	StV_Everybody,
+	StV_Owner,
+	StV_Origin,
+	StV_OwnerAndOrigin,
+	StV_Global,
+	StV_Nobody,
+};
+
+tidy final class StatusType {
+	uint id;
+	string ident;
+	string name;
+	string description;
+	Sprite icon;
+	Color color;
+	StatusVisibility visibility = StV_Everybody;
+
+	bool unique = false;
+	bool collapses = false;
+	array<IStatusHook@> hooks;
+
+	string def_conditionType;
+	const PlanetType@ conditionType;
+	uint conditionTier = 0;
+	double conditionFrequency = 0.0;
+
+	bool shouldApply(Empire@ emp, Region@ region, Object@ obj) const {
+		if(!obj.hasStatuses)
+			return false;
+		for(uint i = 0, cnt = hooks.length; i < cnt; ++i) {
+			if(!hooks[i].shouldApply(emp, region, obj))
+				return false;
+		}
+		return true;
+	}
+};
+
+interface IStatusHook {
+	void onCreate(Object& obj, Status@ status, any@ data);
+	void onDestroy(Object& obj, Status@ status, any@ data);
+	void onObjectDestroy(Object& obj, Status@ status, any@ data);
+	bool onTick(Object& obj, Status@ status, any@ data, double time);
+	void onAddStack(Object& obj, Status@ status, StatusInstance@ instance, any@ data);
+	void onRemoveStack(Object& obj, Status@ status, StatusInstance@ instance, any@ data);
+	bool onOwnerChange(Object& obj, Status@ status, any@ data, Empire@ prevOwner, Empire@ newOwner);
+	bool onRegionChange(Object& obj, Status@ status, any@ data, Region@ prevRegion, Region@ newRegion);
+	void save(Status@ status, any@ data, SaveFile& file);
+	void load(Status@ status, any@ data, SaveFile& file);
+
+	bool shouldApply(Empire@ emp, Region@ region, Object@ obj) const;
+	bool getVariable(Object@ obj, Sprite& sprt, string& name, string& value, Color& color) const;
+};
+
+class StatusHook : Hook, IStatusHook {
+	void onCreate(Object& obj, Status@ status, any@ data) {}
+	void onDestroy(Object& obj, Status@ status, any@ data) {}
+	void onObjectDestroy(Object& obj, Status@ status, any@ data) {}
+	bool onTick(Object& obj, Status@ status, any@ data, double time) { return true; }
+	void onAddStack(Object& obj, Status@ status, StatusInstance@ instance, any@ data) {}
+	void onRemoveStack(Object& obj, Status@ status, StatusInstance@ instance, any@ data) {}
+	bool onOwnerChange(Object& obj, Status@ status, any@ data, Empire@ prevOwner, Empire@ newOwner) { return true; }
+	bool onRegionChange(Object& obj, Status@ status, any@ data, Region@ prevRegion, Region@ newRegion) { return true; }
+	void save(Status@ status, any@ data, SaveFile& file) {}
+	void load(Status@ status, any@ data, SaveFile& file) {}
+	bool shouldApply(Empire@ emp, Region@ region, Object@ obj) const { return true; }
+	bool getVariable(Object@ obj, Sprite& sprt, string& name, string& value, Color& color) const { return false; }
+};
+
+tidy final class Status : Serializable, Savable {
+	const StatusType@ type;
+	int stacks = 0;
+	any[] data;
+	Empire@ originEmpire;
+	Object@ originObject;
+
+	Status() {
+	}
+
+	Status(const StatusType@ type) {
+		set(type);
+	}
+
+	string getTooltip(Object@ valueObject = null) const {
+		string tt;
+
+		string name = type.name;
+		if(!type.unique && stacks > 1)
+			name += format(" (x $1)", toString(stacks));
+		tt = format("[font=Medium][color=$3]$1[/color][/font]\n$2",
+			name, type.description, toString(type.color));
+
+		string vname, vvalue;
+		Sprite vicon;
+		Color color;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i) {
+			if(type.hooks[i].getVariable(valueObject, vicon, vname, vvalue, color)) {
+				tt += format("[nl/]\n[img=$1;22][b][color=$4]$2[/color][/b] [offset=120]$3[/offset][/img]",
+					getSpriteDesc(vicon), vname, vvalue, toString(color));
+				color = colors::White;
+			}
+		}
+		return tt;
+	}
+
+	bool isVisibleTo(Object& obj, Empire@ emp) const {
+		if(emp is null || !emp.valid)
+			return type.visibility == StV_Everybody;
+		switch(type.visibility) {
+			case StV_Everybody:
+			case StV_Global:
+				return true;
+			case StV_Owner:
+				return emp is obj.owner;
+			case StV_Origin:
+				return emp is originEmpire;
+			case StV_OwnerAndOrigin:
+				return emp is originEmpire || emp is obj.owner;
+			case StV_Nobody:
+				return false;
+		}
+		return false;
+	}
+
+	void set(const StatusType@ type) {
+		@this.type = type;
+		stacks = 0;
+		data.length = type.hooks.length;
+	}
+
+	void write(Message& msg) {
+		msg.writeSmall(type.id);
+		msg.writeSmall(stacks);
+		msg << originEmpire;
+		msg << originObject;
+	}
+
+	void read(Message& msg) {
+		@type = getStatusType(msg.readSmall());
+		stacks = msg.readSmall();
+		data.length = type.hooks.length;
+		msg >> originEmpire;
+		msg >> originObject;
+	}
+
+	void save(SaveFile& file) {
+		file.writeIdentifier(SI_Status, type.id);
+		file << stacks;
+		file << originEmpire;
+		file << originObject;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].save(this, data[i], file);
+	}
+
+	void load(SaveFile& file) {
+		@type = getStatusType(file.readIdentifier(SI_Status));
+		file >> stacks;
+		if(file >= SV_0083) {
+			file >> originEmpire;
+			file >> originObject;
+		}
+		data.length = type.hooks.length;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].load(this, data[i], file);
+	}
+
+	void create(Object& obj) {
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].onCreate(obj, this, data[i]);
+	}
+
+	void destroy(Object& obj) {
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].onDestroy(obj, this, data[i]);
+	}
+
+	void objectDestroy(Object& obj) {
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].onObjectDestroy(obj, this, data[i]);
+	}
+
+	StatusInstance@ instance(Object& obj) {
+		StatusInstance inst;
+		@inst.status = this;
+		stacks += 1;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].onAddStack(obj, this, inst, data[i]);
+		return inst;
+	}
+
+	void remove(Object& obj, StatusInstance@ inst) {
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i)
+			type.hooks[i].onRemoveStack(obj, this, inst, data[i]);
+		stacks -= 1;
+	}
+
+	bool tick(Object& obj, double time) {
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i) {
+			if(!type.hooks[i].onTick(obj, this, data[i], time))
+				return false;
+		}
+		return true;
+	}
+
+	bool ownerChange(Object& obj, Empire@ prevOwner, Empire@ newOwner) {
+		bool keep = true;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i) {
+			if(!type.hooks[i].onOwnerChange(obj, this, data[i], prevOwner, newOwner))
+				keep = false;
+		}
+		return keep;
+	}
+
+	bool regionChange(Object& obj, Region@ prevRegion, Region@ newRegion) {
+		bool keep = true;
+		for(uint i = 0, cnt = type.hooks.length; i < cnt; ++i) {
+			if(!type.hooks[i].onRegionChange(obj, this, data[i], prevRegion, newRegion))
+				keep = false;
+		}
+		return keep;
+	}
+};
+
+tidy final class StatusInstance : Savable {
+	Status@ status;
+	int id = -1;
+	double timer = -1.0;
+	Region@ boundRegion;
+	Empire@ boundEmpire;
+
+	void remove(Object& obj) {
+		status.remove(obj, this);
+	}
+
+	bool tick(Object& obj, double time) {
+		if(timer >= 0) {
+			timer -= time;
+			if(timer <= 0) {
+				status.remove(obj, this);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void save(SaveFile& file) {
+		file << id;
+		file << timer;
+		file << boundRegion;
+		file << boundEmpire;
+	}
+
+	void load(SaveFile& file) {
+		file >> id;
+		file >> timer;
+		file >> boundRegion;
+		file >> boundEmpire;
+	}
+};
+
+array<StatusType@> statusTypes;
+dictionary statusIdents;
+
+int getStatusID(const string& ident) {
+	auto@ type = getStatusType(ident);
+	if(type is null)
+		return -1;
+	return int(type.id);
+}
+
+string getStatusIdent(int id) {
+	auto@ type = getStatusType(id);
+	if(type is null)
+		return "";
+	return type.ident;
+}
+
+const StatusType@ getStatusType(uint id) {
+	if(id >= statusTypes.length)
+		return null;
+	return statusTypes[id];
+}
+
+const StatusType@ getStatusType(const string& ident) {
+	StatusType@ def;
+	if(statusIdents.get(ident, @def))
+		return def;
+	return null;
+}
+
+uint getStatusTypeCount() {
+	return statusTypes.length;
+}
+
+const StatusType@ getRandomCondition(Planet& planet) {
+	double roll = randomd();
+	double freq = 0.0;
+	const StatusType@ result;
+	for(uint i = 0, cnt = statusTypes.length; i < cnt; ++i) {
+		auto@ status = statusTypes[i];
+		if(status.conditionFrequency <= 0)
+			continue;
+		if(status.conditionType !is null) {
+			if(planet.PlanetType != status.conditionType.id)
+				continue;
+		}
+		if(status.conditionTier != 0) {
+			auto@ type = getResource(planet.primaryResourceType);
+			if(type is null || type.level < status.conditionTier)
+				continue;
+		}
+		if(!status.shouldApply(planet.owner, planet.region, planet))
+			continue;
+
+		freq += status.conditionFrequency;
+
+		double chance = status.conditionFrequency / freq;
+		if(roll < chance) {
+			@result = status;
+			roll /= chance;
+		}
+		else {
+			roll = (roll - chance) / (1.0 - chance);
+		}
+	}
+	return result;
+}
+
+void saveIdentifiers(SaveFile& file) {
+	for(uint i = 0, cnt = statusTypes.length; i < cnt; ++i) {
+		auto type = statusTypes[i];
+		file.addIdentifier(SI_Status, type.id, type.ident);
+	}
+}
+
+void addStatus(StatusType@ type) {
+	type.id = statusTypes.length;
+	statusTypes.insertLast(type);
+	statusIdents.set(type.ident, @type);
+}
+
+void parseLine(string& line, StatusType@ type, ReadFile@ file) {
+	auto@ hook = cast<IStatusHook>(parseHook(line, "status_effects::", instantiate=false, file=file));
+	if(hook !is null)
+		type.hooks.insertLast(hook);
+}
+
+void loadStatus(const string& filename) {
+	ReadFile file(filename, true);
+	
+	string key, value;
+	StatusType@ status;
+	
+	uint index = 0;
+	while(file++) {
+		key = file.key;
+		value = file.value;
+		
+		if(file.fullLine) {
+			string line = file.line;
+			parseLine(line, status, file);
+		}
+		else if(key.equals_nocase("Status")) {
+			if(status !is null)
+				addStatus(status);
+			@status = StatusType();
+			status.ident = value;
+		}
+		else if(status is null) {
+			file.error("Missing status ID' line");
+		}
+		else if(key.equals_nocase("Name")) {
+			status.name = localize(value);
+		}
+		else if(key.equals_nocase("Description")) {
+			status.description = localize(value);
+		}
+		else if(key.equals_nocase("Icon")) {
+			status.icon = getSprite(value);
+		}
+		else if(key.equals_nocase("Color")) {
+			status.color = toColor(value);
+		}
+		else if(key.equals_nocase("Condition Frequency")) {
+			status.conditionFrequency = toDouble(value);
+		}
+		else if(key.equals_nocase("Condition Tier")) {
+			status.conditionTier = toUInt(value);
+		}
+		else if(key.equals_nocase("Condition Type")) {
+			status.def_conditionType = value;
+		}
+		else if(key.equals_nocase("Unique")) {
+			status.unique = toBool(value);
+			if(status.unique)
+				status.collapses = true;
+		}
+		else if(key.equals_nocase("Collapses")) {
+			status.collapses = toBool(value);
+		}
+		else if(key.equals_nocase("Visible To")) {
+			if(value.equals_nocase("everybody"))
+				status.visibility = StV_Everybody;
+			else if(value.equals_nocase("owner"))
+				status.visibility = StV_Owner;
+			else if(value.equals_nocase("origin empire"))
+				status.visibility = StV_Origin;
+			else if(value.equals_nocase("owner and origin empire"))
+				status.visibility = StV_OwnerAndOrigin;
+			else if(value.equals_nocase("nobody"))
+				status.visibility = StV_Nobody;
+			else if(value.equals_nocase("global"))
+				status.visibility = StV_Global;
+			else
+				file.error("Unknown status visibility: "+value);
+		}
+		else {
+			string line = file.line;
+			parseLine(line, status, file);
+		}
+	}
+	
+	if(status !is null)
+		addStatus(status);
+}
+
+void preInit() {
+	FileList list("data/statuses", "*.txt", true);
+	for(uint i = 0, cnt = list.length; i < cnt; ++i)
+		loadStatus(list.path[i]);
+}
+
+void init() {
+	auto@ list = statusTypes;
+	for(uint i = 0, cnt = list.length; i < cnt; ++i) {
+		auto@ type = list[i];
+		for(uint n = 0, ncnt = type.hooks.length; n < ncnt; ++n)
+			if(!cast<Hook>(type.hooks[n]).instantiate())
+				error("Could not instantiate hook: "+addrstr(type.hooks[n])+" in "+type.ident);
+		if(type.def_conditionType.length != 0) {
+			@type.conditionType = getPlanetType(type.def_conditionType);
+			if(type.conditionType is null)
+				error("Error in Status "+type.ident+": could not find planet type "+type.def_conditionType);
+		}
+	}
+}

--- a/OpenSR/scripts/gui/editor/defs.as
+++ b/OpenSR/scripts/gui/editor/defs.as
@@ -1,0 +1,937 @@
+//Deals with definition specifications. A definition specification takes a loaded datafile
+//structure and defines properties for its fields so it can be represented with a UI.
+
+import hooks;
+import editor.loader;
+import editor.completion;
+import icons;
+
+class FileDef {
+	array<BlockDef@> blocks;
+	BlockDef defaultBlock;
+	BlockDef@ curBlock;
+	string localeFile;
+
+	FileDef() {
+		@curBlock = defaultBlock;
+	}
+
+	BlockDef@ getBlock(const string& key) {
+		return defaultBlock.getBlock(key);
+	}
+
+	BlockDef@ block(const string& key, const string& doc, const string& hookType = "", const string& hookModule = "") {
+		@curBlock = defaultBlock.block(key, doc, hookType, hookModule);
+		curBlock.closeDefault = false;
+		return curBlock;
+	}
+
+	void unblock() {
+		@curBlock = defaultBlock;
+	}
+
+	FieldDef@ field(const string& key, ArgumentType type, const string& defaultValue, const string& doc, const Sprite& icon = Sprite(), bool repeatable = false) {
+		return curBlock.field(key, type, defaultValue, doc, icon, repeatable);
+	}
+
+	void onChange() {}
+};
+
+class BlockDef {
+	string key;
+	string doc;
+	string hookType;
+	string hookModule;
+	string hookPrefix;
+	string editMode;
+	bool hasIdentifier = true;
+	bool identifierLimit = true;
+	bool closeDefault = true;
+	array<BlockDef@> blocks;
+	array<FieldDef@> fields;
+	array<Completion@>@ duplicateCheck;
+
+	BlockDef@ getBlock(const string& key) {
+		for(uint i = 0, cnt = blocks.length; i < cnt; ++i) {
+			if(blocks[i].key == key)
+				return blocks[i];
+		}
+		return null;
+	}
+
+	FieldDef@ getField(const string& key) {
+		for(uint i = 0, cnt = fields.length; i < cnt; ++i) {
+			if(fields[i].key == key)
+				return fields[i];
+		}
+		return null;
+	}
+
+	FieldDef@ getField(LineDesc@ line) {
+		for(uint i = 0, cnt = fields.length; i < cnt; ++i) {
+			if(fields[i].condition is null)
+				continue;
+			if(fields[i].condition.matches(line)) {
+				fields[i].condition.modify(line);
+				return fields[i];
+			}
+		}
+		return null;
+	}
+
+	BlockDef@ block(const string& key, const string& doc, const string& hookType = "", const string& hookModule = "") {
+		BlockDef b;
+		b.key = key;
+		b.doc = doc;
+		b.hookType = hookType;
+		b.hookModule = hookModule;
+		blocks.insertLast(b);
+		return b;
+	}
+
+	FieldDef@ field(const string& key, ArgumentType type, const string& defaultValue, const string& doc, const Sprite& icon = Sprite(), bool repeatable = false) {
+		FieldDef f;
+		f.index = fields.length;
+		f.key = key;
+		f.type = type;
+		f.defaultValue = defaultValue;
+		f.doc = doc;
+		f.icon = icon;
+		f.repeatable = repeatable;
+		fields.insertLast(f);
+		return f;
+	}
+
+	BlockDef& checkDuplicates(array<Completion@>@ dups) {
+		@duplicateCheck = dups;
+		return this;
+	}
+
+	BlockDef& setEditMode(const string& mode) {
+		editMode = mode;
+		return this;
+	}
+};
+
+class FieldCondition {
+	bool matches(LineDesc@ line) { return false; }
+	void modify(LineDesc@ line) {}
+};
+
+class VariableCondition : FieldCondition {
+	bool matches(LineDesc@ line) {
+		if(!line.isKey)
+			return false;
+		if(line.value.length != 0 && line.value[0] == '=')
+			return true;
+		return false;
+	}
+
+	void modify(LineDesc@ line) {
+		line.line = line.key+" :"+line.value;
+		line.isKey = false;
+	}
+};
+
+class ValueCondition : FieldCondition {
+	bool matches(LineDesc@ line) {
+		if(line.isKey)
+			return false;
+		int pos = line.line.findFirst("=");
+		return pos != -1;
+	}
+};
+
+class FieldDef {
+	uint index;
+	string key;
+	string defaultValue;
+	string doc;
+	Sprite icon;
+	ArgumentType type;
+	FieldCondition@ condition;
+	bool fullLine = false;
+	array<string>@ options;
+	bool repeatable = false;
+	int fieldPriority = 0;
+
+	FieldDef& setOptions(array<string>@ opts) {
+		@options = opts;
+		return this;
+	}
+
+	FieldDef& setCondition(FieldCondition@ cond) {
+		@this.condition = cond;
+		return this;
+	}
+
+	FieldDef& setFullLine(bool value) {
+		this.fullLine = value;
+		return this;
+	}
+
+	FieldDef& setPriority(int prior) {
+		fieldPriority = prior;
+		return this;
+	}
+};
+
+class StatusFile : FileDef {
+	array<string> visibilities = {"Everybody", "Owner", "Origin Empire", "Owner and Origin Empire", "Nobody", "Global"};
+
+	StatusFile() {
+		localeFile = "statuses.txt";
+		block("Status", doc="A type of status effect that can be added to an object.",
+				hookType="statuses::IStatusHook", hookModule="status_effects").checkDuplicates(statusCompletions);
+			field("Name", AT_Locale, "", doc="Name of the status.");
+			field("Description", AT_Locale, "", doc="Description of the status.");
+			field("Icon", AT_Sprite, "", doc="Icon used to represent the status.");
+			field("Color", AT_Color, "", doc="The status' representative color.");
+			field("Condition Frequency", AT_Decimal, "0", doc="How often this status appears on planets as a planet condition, relative to other statuses' condition frequency.");
+			field("Condition Tier", AT_Integer, "0", doc="The minimum level the planet's resource must be for this status to be able to appear as a planet condition.");
+			field("Condition Type", AT_Custom, "", doc="The planet type a planet must have in order for this status to be able to appear as a planet condition..");
+			field("Unique", AT_Boolean, "False", doc="Unique statuses indicate that the status cannot affect an object more than once, so should not be given a stack count display.");
+			field("Collapses", AT_Boolean, "False", doc="A status that collapses will show a stack count instead of being a separate status for each instance. The status hooks are responsible for dealing with stack counts on an individual basis.");
+			field("Visible To", AT_Selection, "Everybody", doc="Which empires the status can be seen by when looking at the object.").setOptions(visibilities);
+	}
+
+	void onChange() {
+		loadCompletions(statusCompletions, "data/statuses", "Status");
+	}
+};
+
+class AbilityFile : FileDef {
+	AbilityFile() {
+		localeFile = "abilities.txt";
+		block("Ability", doc="An ability that objects can trigger.",
+				hookType="abilities::IAbilityHook", hookModule="ability_effects").checkDuplicates(abilityCompletions);
+			field("Name", AT_Locale, "", doc="Name of the ability.");
+			field("Description", AT_Locale, "", doc="Description of the ability.");
+			field("Icon", AT_Sprite, "", doc="Icon used to represent the ability.");
+			field("Energy Cost", AT_Decimal, "0", doc="The base energy cost to activate the ability. Can be modified further by hooks.");
+			field("Cooldown", AT_Decimal, "0", doc="The base cooldown between uses of the ability. Can be modified further by hooks.");
+			field("Range", AT_Decimal, "", doc="The base maximum distance that the ability can be casted from. Can be modified further by hooks.");
+			field("Hotkey", AT_Custom, "", doc="If set, create a hotkey for activating this ability when the object is selected to the specified key combination.");
+			field("Hide Global", AT_Boolean, "False", doc="Hide this from the global action bar if added as an empire ability.");
+			field("Target", AT_TargetSpec, "", /*repeatable=true,*/ doc="A type of target this ability needs to be triggered on.");
+			field("Activate Sound", AT_Custom, "", doc="Name of the sound effect to be played in the UI for the person that triggers this ability.");
+	}
+
+	void onChange() {
+		loadCompletions(abilityCompletions, "data/abilities", "Ability");
+	}
+};
+
+class AnomalyFile : FileDef {
+	AnomalyFile() {
+		localeFile = "anomalies.txt";
+		auto@ anom = block("Anomaly", doc="A type of anomaly that can be investigated.").checkDuplicates(anomalyCompletions);
+			anom.field("Name", AT_Locale, "", doc="Name of the anomaly.");
+			anom.field("Description", AT_Locale, "", doc="Basic, unscanned description of the anomaly.");
+			anom.field("Narrative", AT_Locale, "", doc="Narrative for a scanned anomaly not in any state.");
+			anom.field("Model", AT_Model, "Debris", doc="Model for the unscanned anomaly.");
+			anom.field("Material", AT_Material, "Asteroid", doc="Model material for the unscanned anomaly.");
+			anom.field("Frequency", AT_Decimal, "1", doc="How often this anomaly appears, relative to other anomalies' frequency.");
+			anom.field("Scan Time", AT_Decimal, "60", doc="Amount of time in seconds that the anomaly takes to scan.");
+			anom.field("Unique", AT_Boolean, "False", doc="Whether this anomaly is unique and can only occur once in a game.");
+
+		auto@ state = anom.block("State", doc="One of the states that the anomaly can trigger when scanned.");
+			state.field("Narrative", AT_Locale, "", doc="Description of the anomaly in this state.");
+			state.field("Model", AT_Model, "Debris", doc="Model for the anomaly in this state.");
+			state.field("Material", AT_Material, "Asteroid", doc="Model material for the anomaly in this state.");
+			state.field("Frequency", AT_Decimal, "1", doc="How often the anomaly scans to this state, relative to other states' frequency.");
+			state.field("Choice", AT_Custom, "", repeatable=true, doc="Indicates an available choice when the anomaly is in this state.");
+
+		auto@ option = anom.block("Option", doc="One of the option choices that can be added to a state.",
+				hookType="anomalies::IAnomalyHook", hookModule="anomaly_effects");
+			option.field("Description", AT_Locale, "", doc="The description for triggering the option.");
+			option.field("Icon", AT_Sprite, "", doc="Icon used to represent the option.");
+			option.field("Chance", AT_Custom, "100%", doc="Chance for this option to appear, if no specific chance is given in the state.");
+			option.field("Safe", AT_Boolean, "True", doc="Whether this option is safe and cannot result in unwanted consequences. Mainly used by the AI for decision making.");
+			option.field("Target", AT_TargetSpec, "", /*repeatable=true,*/ doc="A type of target this option needs to be triggered on.");
+
+		auto@ result = option.block("Result", doc="A possible result when the option is chosen.",
+			hookType="anomalies::IAnomalyHook", hookModule="anomaly_effects");
+		result.identifierLimit = false;
+	}
+
+	void onChange() {
+		loadCompletions(anomalyCompletions, "data/anomalies", "Anomaly");
+	}
+};
+
+class ArtifactFile : FileDef {
+	ArtifactFile() {
+		localeFile = "artifacts.txt";
+		block("Artifact", doc="A type of artifact that can be found and used.").checkDuplicates(artifactCompletions);
+			field("Name", AT_Locale, "", doc="Name of the artifact.");
+			field("Description", AT_Locale, "", doc="Description of what the artifact does.");
+			field("Icon", AT_Sprite, "ArtifactIcon::0", doc="Icon used to represent the artifact on the interface.");
+			field("Strategic Icon", AT_Sprite, "ArtifactIcon::0", doc="Icon used for the artifact at strategic zoom.");
+			field("Icon Size", AT_Decimal, "0.02", doc="Size of the artifact's distant icon.");
+			field("Model", AT_Model, "Artifact", doc="Model for the artifact.");
+			field("Material", AT_Material, "VolkurGenericPBR", doc="Model material for the artifact.");
+			field("Physical Size", AT_Decimal, "5.0", doc="Physical size of the artifact in the world.");
+			field("Mass", AT_Decimal, "300", doc="Mass of the artifact. Affects tractor beams.");
+			field("Frequency", AT_Decimal, "1", doc="How often this artifact appears, relative to other artifacts' frequency.");
+			field("Time Frequency", AT_Decimal, "0", doc="Increase to the artifact's base frequency for every 20 minutes of game time that passes.");
+			field("Single Use", AT_Boolean, "True", doc="Whether the artifact disappears after it has been used once.");
+			field("Single Use", AT_Boolean, "True", doc="Whether the artifact disappears after it has been used once.");
+			field("Orbit", AT_Boolean, "False", doc="Whether the artifact orbits the star or stays at a static position.");
+			field("Unique", AT_Boolean, "False", doc="Unique artifacts can only be generated into the galaxy once.");
+			field("Natural", AT_Boolean, "False", doc="Natural artifacts are not generated by seed ships, but only spawn when the game starts.");
+			field("Collapses", AT_Boolean, "True", doc="Whether multiple instances of this artifact are considered the same, and collapsed into a stacked view.");
+			field("Can Donate", AT_Boolean, "True", doc="Whether this artifact can be donated to another player.");
+			field("Can Own", AT_Boolean, "True", doc="Whether it is possible for a player to gain exclusive access to this artifact.");
+			field("Require Contestation", AT_Decimal, "0", doc="If nonzero, this artifact type can only spawn in systems with a minimum contestation value. Contestation is an abstract number based on how many empires are close enough to potentially contest the system.");
+			field("Spread Variable", AT_Custom, "", doc="If specified, turns this artifact into a 'Spread Artifact'. If the game_config parameter specified is active, exactly one instance of this artifact will be created when the universe is generated. Implies False for Can Donate and Can Own, and a 0 Frequency.");
+			field("Tag", AT_Custom, "", repeatable=true, doc="Add a named tag to this artifact.");
+			field("Ability", AT_Ability, "", repeatable=true, doc="This artifact grants the capability of using the specified ability.");
+			field("AI", AT_Custom, "", repeatable=true, doc="Behaviour the AI follows for using this artifact.");
+	}
+
+	void onChange() {
+		loadCompletions(artifactCompletions, "data/artifacts", "Artifact");
+	}
+};
+
+class InfluenceFile : FileDef {
+	array<string> cardClasses = {"Support", "Vote", "Effect", "Action", "Event", "Instant", "Misc"};
+	array<string> cardRarities = {"Common", "Uncommon", "Rare", "Epic", "Basic"};
+	array<string> cardSides = {"Neutral", "Both", "Oppose", "Support"};
+
+	InfluenceFile() {
+		localeFile = "diplomacy.txt";
+		auto@ card = block("Card", doc="A type of influence card.",
+				hookType="influence::InfluenceCardEffect", hookModule="card_effects").checkDuplicates(cardCompletions);
+			card.field("Name", AT_Locale, "", doc="Title of the card.");
+			card.field("Description", AT_Locale, "", doc="Description of the card.");
+			card.field("Icon", AT_Sprite, "", doc="Icon used to represent the card.");
+			card.field("Color", AT_Color, "", doc="The card's representative color.");
+			card.field("Frequency", AT_Decimal, "-1", doc="How often this card appears in the deck. A value of -1 indicates the frequency is dependent on the card rarity.");
+			card.field("Collapse Uses", AT_Boolean, "True", doc="Whether multiple uses of this card should be considered the same and collapsed into a stack.");
+			card.field("Points", AT_Integer, "0", doc="How many points this card adds to the empire's point total, in addition to basic points based on rarity.");
+			card.field("Leader Only", AT_Boolean, "False", doc="Whether only the senate leader can play this card.");
+			card.field("Class", AT_Selection, "Misc", doc="The type of card this is.").setOptions(cardClasses);
+			card.field("Rarity", AT_Selection, "Common", doc="The rarity of this card in the deck.").setOptions(cardRarities);
+			card.field("Side", AT_Selection, "Neutral", doc="For support cards, which sides of the vote the card can be played on.").setOptions(cardSides);
+			card.field("Base Purchase Cost", AT_Integer, "0", doc="The base influence cost to buy the card off the stack.");
+			card.field("Quality Purchase Cost", AT_Integer, "0", doc="The additional influence cost per extra quality this card costs to buy off the stack.");
+			card.field("Uses Purchase Cost", AT_Integer, "0", doc="The additional influence cost per use this card costs to buy off the stack.");
+			card.field("Placement Purchase Cost", AT_Integer, "1", doc="How much influence each space in the card stack the buy cost increases by.");
+			card.field("Base Play Cost", AT_Integer, "0", doc="The base influence cost to play this card.");
+			card.field("Quality Play Cost", AT_Integer, "0", doc="The additional influence cost per quality this card costs to play.");
+			card.field("Base Weight", AT_Integer, "0", doc="For support cards, the base weight this adds to a vote.");
+			card.field("Quality Weight", AT_Integer, "0", doc="For support cards, the extra weight this adds to a vote per extra quality.");
+			card.field("Min Quality", AT_Integer, "1", doc="The minimum quality this card appears in the stack with.");
+			card.field("Max Quality", AT_Integer, "1", doc="The maximum quality this card appears in the stack with.");
+			card.field("Can Overquality", AT_Boolean, "True", doc="Whether this card can be boosted beyond its max quality. (For example, by Enhance cards)");
+			card.field("Min Uses", AT_Integer, "1", doc="The minimum uses this card appears in the stack with.");
+			card.field("Max Uses", AT_Integer, "1", doc="The maximum uses this card appears in the stack with.");
+			card.field("Target", AT_TargetSpec, "", repeatable=true, doc="A type of target this card needs to be triggered on.");
+			card.field("AI", AT_Custom, "", repeatable=true, doc="Behaviour the AI follows for using this card.");
+
+		auto@ vote = block("Vote", doc="A type of influence vote.",
+				hookType="influence::InfluenceVoteEffect", hookModule="vote_effects").checkDuplicates(voteCompletions);
+			vote.field("Name", AT_Locale, "", doc="Title of the vote.");
+			vote.field("Description", AT_Locale, "", doc="Description of the vote.");
+			vote.field("Icon", AT_Sprite, "", doc="Icon used to represent the vote.");
+			vote.field("Color", AT_Color, "", doc="The vote's representative color.");
+			vote.field("Target", AT_TargetSpec, "", /*repeatable=true,*/ doc="A type of target this vote needs to be triggered on.");
+			vote.field("AI", AT_Custom, "", repeatable=true, doc="Behaviour the AI follows for judging this vote.");
+
+		auto@ effect = block("Effect", doc="A type of persistent influence effect.",
+				hookType="influence::InfluenceEffectEffect", hookModule="influence_effects").checkDuplicates(effectCompletions);
+			effect.field("Name", AT_Locale, "", doc="Title of the effect.");
+			effect.field("Description", AT_Locale, "", doc="Description of the effect.");
+			effect.field("Icon", AT_Sprite, "", doc="Icon used to represent the effect.");
+			effect.field("Color", AT_Color, "", doc="The effect's representative color.");
+			effect.field("Default Duration", AT_Decimal, "-1", doc="The default duration an effect of this type has when triggered. A negative value indicates a permanent effect.");
+			effect.field("Upkeep", AT_Decimal, "0.0", doc="The portion of influence generation having this effect active consumes, from 0.0 to 1.0.");
+			effect.field("Dismissable", AT_Boolean, "True", doc="Whether this effect can be dismissed at will.");
+			effect.field("Dismiss Needs Owner", AT_Boolean, "True", doc="Whether only the owner of the effect can dismiss it at will.");
+			effect.field("Target", AT_TargetSpec, "", /*repeatable=true,*/ doc="A type of target this effect needs to be triggered on.");
+			effect.field("Tag", AT_Custom, "", repeatable=true, doc="A tag added to the effect for future identification.");
+
+		auto@ clause = block("Clause", doc="A clause that can be added to a treaty.",
+				hookType="influence::InfluenceClauseHook", hookModule="clause_effects");
+			clause.field("Name", AT_Locale, "", doc="Title of the clause.");
+			clause.field("Description", AT_Locale, "", doc="Description of the clause.");
+			clause.field("Icon", AT_Sprite, "", doc="Icon used to represent the clause.");
+			clause.field("Color", AT_Color, "", doc="The clause's representative color.");
+			clause.field("Free Clause", AT_Boolean, "False", doc="Whether this clause is available to be added freely to any treaty an empire wants to make.");
+			clause.field("Team Clause", AT_Boolean, "False", doc="Whether this clause should be added to treaties created for 'Teams' from the game settings.");
+			clause.field("Default Clause", AT_Boolean, "False", doc="Whether this clause is checked to be added by default for new treaties, and needs to be unchecked if players do not want to propose it.");
+	}
+
+	void onChange() {
+		loadCompletions(cardCompletions, "data/influence", "Card");
+		loadCompletions(voteCompletions, "data/influence", "Vote");
+		loadCompletions(effectCompletions, "data/influence", "Effect");
+	}
+};
+
+class ResearchFile : FileDef {
+	array<string> classes = {"Boost", "Upgrade", "BigUpgrade", "Unlock", "Keystone", "Secret", "Special"};
+
+	ResearchFile() {
+		localeFile = "research.txt";
+		block("Technology", doc="A type of technology that can be placed on the research grid.",
+				hookType="research::ITechnologyHook", hookModule="research_effects").checkDuplicates(techCompletions);
+			field("Name", AT_Locale, "", doc="Name of the technology.");
+			field("Blurb", AT_Locale, "", doc="Very short description of the technology's effects, for display on the grid.");
+			field("Description", AT_Locale, "", doc="Description of the technology.");
+			field("Class", AT_Selection, "Upgrade", doc="The type of technology. For display purposes.").setOptions(classes);
+			field("Category", AT_Custom, "", doc="The category the technology is listed under in the research editor. No effect on the game.");
+			field("Icon", AT_Sprite, "", doc="Icon used to represent the technology.");
+			field("Symbol", AT_Sprite, "", doc="Additional symbol displayed on the technology icon.");
+			field("Color", AT_Color, "", doc="The technology's representative color.");
+			field("Point Cost", AT_Decimal, "0", doc="The base amount of research points this technology costs to research.");
+			field("Time Cost", AT_Decimal, "0", doc="The base time in seconds this technology takes to research.");
+			field("Default Unlock", AT_Boolean, "False", doc="Whether all nodes of this technology type start unlocked by default.");
+			field("Secret", AT_Boolean, "False", doc="Whether this is a secret project technology.");
+		block("Grid", doc="A grid or grid overlay that can be loaded. Must be in its own separate file.").setEditMode("research_grid");
+	}
+
+	void onChange() {
+		loadCompletions(techCompletions, "data/research", "Technology");
+	}
+};
+
+class AttitudeFile : FileDef {
+	AttitudeFile() {
+		localeFile = "attitudes.txt";
+		auto@ attid = block("Attitude", doc="An attitude that can be taken by an empire.",
+				hookType="attitudes::IAttitudeHook", hookModule="attitude_effects").checkDuplicates(attitudeCompletions);
+			attid.field("Name", AT_Locale, "", doc="Name of the attitude.");
+			attid.field("Description", AT_Locale, "", doc="Description of the attitude.");
+			attid.field("Progress", AT_Locale, "", doc="Locale entry used to display the attitude's progress indicator.");
+			attid.field("Sort", AT_Integer, "0", doc="Sort order for the attitude in the list.");
+			attid.field("Color", AT_Color, "", doc="The attitude's representative color.");
+
+		auto@ level = attid.block("Level", doc="A level that can be reached in this attitude.",
+				hookType="attitudes::IAttitudeHook", hookModule="attitude_effects");
+		level.hasIdentifier = false;
+			level.field("Description", AT_Locale, "", doc="Description for the effect this level has.");
+			level.field("Icon", AT_Sprite, "", doc="Icon to display this level on the bar.");
+			level.field("Threshold", AT_Decimal, "0", doc="The amount of progress that needs to be made in this attitude to unlock this level.");
+	}
+
+	void onChange() {
+		loadCompletions(attitudeCompletions, "data/attitudes", "Attitude");
+	}
+};
+
+class ResourceFile : FileDef {
+	array<string> vanishModes = {"Never", "Always", "When Exported", "Exported In Combat", "Custom"};
+	array<string> resourceModes = {"Normal", "Universal", "Universal Unique", "Non Requirement"};
+	array<string> resourceRarities = {"Common", "Uncommon", "Rare", "Epic", "Mythical", "Unique"};
+	array<string> affinityTypes = {
+		"", "Money", "Influence", "Energy", "Research", "Defense", "Labor",
+		"Money + Influence", "Energy + Money", "Research + Defense", "Energy + Defense",
+		"Influence + Research", "ALL"
+	};
+
+	ResourceFile() {
+		localeFile = "resources.txt";
+		block("Resource", doc="A type of resource that can be found in the galaxy.",
+				hookType="resources::IResourceHook", hookModule="resource_effects").checkDuplicates(resourceCompletions);
+			field("Name", AT_Locale, "", doc="Name of the resource.");
+			field("Description", AT_Locale, "", doc="Full description of the resource.");
+			field("Blurb", AT_Locale, "", doc="Short blurb to describe the resource. Defaults to Description if left empty.");
+			field("Small Icon", AT_Sprite, "", doc="Small icon used for compact interface display, and on the planet's distant icon in the 3D world.");
+			field("Icon", AT_Sprite, "", doc="Large icon used in detailed interface display.");
+			field("Native Biome", AT_PlanetBiome, "", doc="The biome that is most likely to hold this resource.");
+			field("Class", AT_Custom, "", doc="Identifier of the resource class this belongs in.");
+			field("Level", AT_Integer, "0", doc="The planet level required to produce this resource.");
+			field("Frequency", AT_Decimal, "1", doc="Global multiplier to the occurrence of this resource, at the expense of every other resource.");
+			field("Distribution", AT_Decimal, "1", doc="Multiplier to the occurrence of this resource in its level/rarity class.");
+			field("Cargo Worth", AT_Integer, "0", doc="How much money killing a cargo ship is worth per unit of resource. Civilian ships carry multiple units of a resource, dependent on their type and size of ship.");
+			field("Artificial", AT_Boolean, "False", doc="Whether this is considered an 'artificial' resource and not affected by terraforming.");
+			field("Exportable", AT_Boolean, "True", doc="Whether this resource can be exported from its original planet, or is static on its source.");
+			field("Unique", AT_Boolean, "False", doc="A unique resource can only be generated in one system in the entire universe.");
+			field("Require Contestation", AT_Decimal, "0", doc="If nonzero, this resource type can only spawn in systems with a minimum contestation value. Contestation is an abstract number based on how many empires are close enough to potentially contest the system.");
+			field("Mode", AT_Selection, "Normal", doc="How this resource affects planet levelup. Universal resources (Drugs) can count as any other resource. Universal Unique resources only work once per planet.").setOptions(resourceModes);
+			field("Rarity", AT_Selection, "Common", doc="The resource's base rarity level.").setOptions(resourceRarities);
+			field("Display Requirement", AT_Boolean, "True", doc="Whether this resource should be listed as a possibility for levelup, regardless of whether it can actually be used.");
+			field("Display Weight", AT_Integer, "0", doc="What order this resource should be displayed in relative to other resources in a list.");
+			field("Asteroid Frequency", AT_Decimal, "0", doc="How often this resource appears on asteroids, relative to other resources that appear on asteroids.");
+			field("Asteroid Labor", AT_Decimal, "0", doc="The base amount of labor this resource costs to build an asteroid base for.");
+			field("Terraform Cost", AT_Integer, "0", doc="Base amount of money it takes to terraform a planet to this resource.");
+			field("Terraform Labor", AT_Integer, "0", doc="Base amount of labor it takes to terraform a planet to this resource.");
+			field("Limitless Level", AT_Boolean, "False", doc="Whether the resource level counts as being a limitless level, instead of its minimum level for penalty purposes.");
+			field("Rarity Level", AT_Integer, "-1", doc="If not set to -1, override the occurrence of this resource as if it was a different level.");
+			field("Vanish Time", AT_Decimal, "-1", doc="For temporary resources, the amount of time before the resource vanishes.");
+			field("Vanish Mode", AT_Selection, "Never", doc="Condition for when the resource is ticking down or not.").setOptions(vanishModes);
+			field("Can Be Terraformed", AT_Boolean, "True", doc="Whether planets with this as their primary resource can be terraformed to something else.");
+			field("Pressure", AT_TileResourceSpec, "", repeatable=true, doc="An amount of pressure this resource provides.");
+			field("Affinity", AT_Selection, "", repeatable=true, doc="A resource's affinities indicate what types of resources it is associated with. Icons for each of the specified affinities will be shown next to the name of the resource. These do not currently have a gameplay effect.")
+				.setOptions(affinityTypes);
+	}
+
+	void onChange() {
+		loadCompletions(resourceCompletions, "data/resources", "Resource");
+	}
+};
+
+class BuildingFile : FileDef {
+	BuildingFile() {
+		localeFile = "buildings.txt";
+		block("Building", doc="A type of building that is built on a planet surface.",
+			hookType="buildings::IBuildingHook", hookModule="building_effects").checkDuplicates(buildingCompletions);
+			field("Name", AT_Locale, "", doc="Name of the building.");
+			field("Description", AT_Locale, "", doc="Description of the building.");
+			field("Sprite", AT_Sprite, "", doc="Picture used to display the building.");
+			field("Category", AT_Custom, "", doc="Category under which the building is listed in the build list.");
+			field("Size", AT_Custom, "1x1", doc="Size in tiles of the building on the surface grid.");
+			field("Base Cost", AT_Integer, "0", doc="Base money cost to purchase this imperial building.");
+			field("Tile Cost", AT_Integer, "0", doc="Extra build cost added for every tile that is not developed.");
+			field("Base Maintenance", AT_Integer, "0", doc="Base maintenance cost for this imperial building.");
+			field("Tile Maintenance", AT_Integer, "0", doc="Extra maintenance cost for every tile of the building that is not developed.");
+			field("Labor Cost", AT_Decimal, "0", doc="How much labor this building costs to construct.");
+			field("In Queue", AT_Boolean, "False", doc="Whether this building should be built in the construction queue. Automatically enabled if a labor cost is specified.");
+			field("Build Time", AT_Decimal, "0", doc="For buildings with no labor cost, the time it takes to construct on the surface.");
+			field("Civilian", AT_Boolean, "False", doc="Whether this is a civilian building.");
+			field("Upgrades From", AT_Building, "", doc="For civilian buildings, what other building this is an 'upgrade' to.");
+			field("City", AT_Boolean, "False", doc="Whether this is a city.");
+			field("Saturation", AT_TileResourceSpec, "", repeatable=true, doc="For civilian structures, the amount of pressure this building takes up to be built.");
+			field("Production", AT_TileResourceSpec, "", repeatable=true, doc="For civilian structures, the amount of units of resource generation this building grants.");
+			field("Pressure Cap", AT_Integer, "1", repeatable=true, doc="For civilian structures, the amount of pressure capacity this building takes up from the total cap when built.");
+			field("Build Affinity", AT_PlanetBiome, "", repeatable=true, doc="Undeveloped tiles of the specified biome do not add their 'Tile Cost' to the building's initial build cost.");
+			field("Maintenance Affinity", AT_PlanetBiome, "", repeatable=true, doc="Undeveloped tiles of the specified biome do not add their 'Maintenance Cost' to the building's maintenance cost.");
+	}
+
+	void onChange() {
+		loadCompletions(buildingCompletions, "data/buildings", "Building");
+	}
+};
+
+class ConstructionFile : FileDef {
+	ConstructionFile() {
+		localeFile = "constructions.txt";
+		block("Construction", doc="A construction that can be built generically.",
+			hookType="constructions::IConstructionHook", hookModule="construction_effects").checkDuplicates(constructionCompletions);
+			field("Name", AT_Locale, "", doc="Name of the construction.");
+			field("Description", AT_Locale, "", doc="Description of the construction.");
+			field("Icon", AT_Sprite, "", doc="Picture used to display the construction.");
+			field("Category", AT_Custom, "", doc="Category under which the construction is listed in the build list.");
+			field("Build Cost", AT_Integer, "0", doc="Base money cost for constructing this.");
+			field("Labor Cost", AT_Integer, "0", doc="Base labor cost for constructing this. Only one of Time or Labor cost must be specified.");
+			field("Time Cost", AT_Integer, "0", doc="Time cost for constructing this, independent of labor generation. Only one of Time or Labor cost must be specified.");
+			field("Maintenance Cost", AT_Integer, "0", doc="Base maintenance for constructing this. Note: Applied permanently after being constructed.");
+			field("Target", AT_TargetSpec, "", /*repeatable=true,*/ doc="A type of target this construction needs to be triggered on.");
+			field("In Context", AT_Boolean, "False", doc="Whether to show this construction in the context menu where appropriate.");
+	}
+
+	void onChange() {
+		loadCompletions(constructionCompletions, "data/constructions", "Construction");
+	}
+};
+
+class BiomeFile : FileDef {
+	BiomeFile() {
+		localeFile = "biomes.txt";
+		block("Biome", doc="A type of biome for on a planet.").checkDuplicates(biomeCompletions);
+			field("Name", AT_Locale, "", doc="Title of the biome.");
+			field("Description", AT_Locale, "", doc="Description of the biome.");
+			field("Sprite", AT_Sprite, "", doc="Icon used to represent the biome.");
+			field("Color", AT_Color, "", doc="The biome's representative color.");
+			field("Temperature", AT_Decimal, "0.5", doc="The biome's relative temperature, from 0 to 1.");
+			field("Humidity", AT_Decimal, "0.5", doc="The biome's relative humidity, from 0 to 1.");
+			field("Frequency", AT_Integer, "1", doc="The relative frequency this biome appears in.");
+			field("UseWeight", AT_Decimal, "1", doc="Relative weight for civilians to develop this tile compared to other tiles.");
+			field("BuildCost", AT_Decimal, "1", doc="Multiplier to imperial building cost on this tile.");
+			field("BuildTime", AT_Decimal, "1", doc="Multiplier to civilian build time of this tile.");
+			field("IsVoid", AT_Boolean, "False", doc="Whether this is a void.");
+			field("IsWater", AT_Boolean, "False", doc="Whether this is water.");
+			field("IsCrystallic", AT_Boolean, "False", doc="Whether this is crystallic.");
+			field("IsMoon", AT_Boolean, "False", doc="Whether this is on a moon.");
+			field("Buildable", AT_Boolean, "False", doc="Whether this can have buildings on it.");
+			field("Picks", AT_Custom, "", doc="Special UV values for biomes using the procedural planet shader.");
+			field("Lookup Range", AT_Custom, "", doc="Special UV values for biomes using the procedural planet shader.");
+	}
+
+	void onChange() {
+		loadCompletions(biomeCompletions, "data/biomes", "Biome");
+	}
+};
+
+class CreepFile : FileDef {
+	CreepFile() {
+		localeFile = "creeps.txt";
+		auto@ camp = block("Camp", doc="A particular type of remnant camp that can be spawned.").checkDuplicates(creepCompletions);
+			camp.field("Frequency", AT_Decimal, "1", doc="Frequency of this camp spawning, relative to other types of camps' frequency.");
+			camp.field("Ship", AT_Custom, "", repeatable=true, doc="A remnant ship spawned to defend the pickup in this camp.");
+			camp.field("Target Strength", AT_Decimal, "", doc="If specified, generate a random fleet close to the specified strength.");
+			camp.field("Flagship Size", AT_Integer, "", doc="If specified, generate a random remnant design of this size to protect the camp.");
+			camp.field("Support Occupation", AT_Decimal, "1.0", doc="If a flagship size is specified for a randomized design, how much of its support capacity should be filled with support ships.");
+			camp.field("Remnant Status", AT_Status, "", repeatable=true, doc="Add a status effect that is added to all remnant flagships generated in this creep camp.");
+			camp.field("Region Status", AT_Status, "", repeatable=true, doc="While this camp is not yet defeated, all objects in the system it is in are given the specified status.");
+
+		auto@ pickup = camp.block("Pickup", doc="A possible type of pickup reward to be spawned with this camp.",
+				hookType="pickup_effects::IPickupHook", hookModule="pickup_effects");
+			pickup.field("Frequency", AT_Decimal, "1", doc="Frequency of the camp having this pickup, relative to the other pickups' frequency.");
+			pickup.field("Name", AT_Locale, "", doc="Name of the pickup.");
+			pickup.field("Description", AT_Locale, "", doc="Description of the pickup.");
+			pickup.field("Verb", AT_Locale, "#VERB_PICKUP", doc="Verb used for the pickup option.");
+			pickup.field("Model", AT_Model, "Research_Station", doc="Model for the pickup.");
+			pickup.field("Material", AT_Material, "GenericPBR_Research_Station", doc="Model material for the pickup.");
+			pickup.field("Physical Size", AT_Decimal, "5.0", doc="Physical size of the pickup in the world.");
+	}
+
+	void onChange() {
+		loadCompletions(creepCompletions, "data/creeps", "Camp");
+	}
+};
+
+class OrbitalFile : FileDef {
+	OrbitalFile() {
+		localeFile = "orbitals.txt";
+		block("Module", doc="A type of orbital module that can be constructed.",
+				hookType="orbital_effects::IOrbitalEffect", hookModule="orbital_effects").checkDuplicates(orbitalCompletions);
+			field("Name", AT_Locale, "", doc="Name of the orbital.");
+			field("Description", AT_Locale, "", doc="Description of the orbital.");
+			field("Blurb", AT_Locale, "", doc="Short blurb to describe the orbital. Defaults to Description if left empty.");
+			field("Icon", AT_Sprite, "", doc="Icon used to represent the orbital.");
+			field("Icon Size", AT_Decimal, "0.03", doc="Size of the orbitals's distant icon.");
+			field("Distant Icon", AT_Sprite, "", doc="Icon used in the 3D view on the orbital's distant icon.");
+			field("Strategic Icon", AT_Sprite, "", doc="Icon used in the 3D view for the orbital's strategic icon.");
+			field("Spin", AT_Decimal, "30", doc="Speed at which the orbital spins.");
+			field("Solid", AT_Boolean, "True", doc="Whether the orbital is considered solid and pushes things away.");
+			field("Maintenance", AT_Integer, "0", doc="The orbital's maintenance cost.");
+			field("Build Cost", AT_Integer, "0", doc="The orbital's build cost.");
+			field("Labor Cost", AT_Decimal, "0", doc="The orbital's labor cost.");
+			field("Combat Repair", AT_Boolean, "True", doc="Whether the orbital can repair when in combat.");
+			field("Can Fling", AT_Boolean, "True", doc="Whether this orbital can be FTLed with fling.");
+			field("Health", AT_Decimal, "0", doc="The orbital's base maximum health.");
+			field("Armor", AT_Decimal, "0", doc="The orbital's base maximum armor. Armor is additional health on top of base health that has damage reduction.");
+			field("Size", AT_Decimal, "10", doc="The physical size of the orbital in the world.");
+			field("Mass", AT_Decimal, "-1", doc="The physical mass of the orbital (used in tractoring). Set to -1 to auto-calculate based on Size.");
+			field("Model", AT_Model, "", doc="Model for the orbital.");
+			field("Material", AT_Material, "", doc="Model material for the orbital.");
+	}
+
+	void onChange() {
+		loadCompletions(orbitalCompletions, "data/orbitals", "Module");
+	}
+};
+
+class TraitFile : FileDef {
+	TraitFile() {
+		localeFile = "traits.txt";
+		block("Trait", doc="A trait that can be taken at game start.",
+				hookType="trait_effects::ITraitEffect", hookModule="trait_effects").checkDuplicates(traitCompletions);
+			field("Name", AT_Locale, "", doc="Name of the trait.");
+			field("Description", AT_Locale, "", doc="Description of the trait.");
+			field("Icon", AT_Sprite, "", doc="Icon used to represent the trait.");
+			field("Color", AT_Color, "", doc="The trait's representative color.");
+			field("Costs Points", AT_Integer, "0", doc="Amount of points this trait costs to take.");
+			field("Gives Points", AT_Integer, "0", doc="Amount of points this trait gives when taken.");
+			field("Category", AT_Custom, "", doc="Category that the trait is listed in.");
+			field("Order", AT_Integer, "0", doc="Order of the trait in the category's list.");
+			field("Unique", AT_Custom, "", doc="If specified, only one trait with the same 'unique' tag can be chosen at a time.");
+			field("Default", AT_Boolean, "False", doc="Whether this trait should be chosen by default.");
+			field("AI Support", AT_Boolean, "True", doc="Whether the AI knows how to deal with this trait.");
+			field("Available", AT_Boolean, "True", doc="Whether this trait is available to be chosen at all.");
+			field("Conflict", AT_Trait, "", repeatable=true, doc="Another trait that cannot be taken at the same time as this trait.");
+	}
+
+	void onChange() {
+		loadCompletions(traitCompletions, "data/traits", "Trait");
+	}
+};
+
+class SubsystemFile : FileDef {
+	SubsystemFile() {
+		localeFile = "subsystems.txt";
+		auto@ sys = block("Subsystem", doc="A subsystem type that can be placed on a design.",
+				hookType="subsystem_effects::SubsystemHook", hookModule="subsystem_effects").checkDuplicates(subsysCompletions);
+		sys.hookPrefix = "Hook: ";
+		sys.field("Name", AT_Locale, "", doc="The subsystem's name.");
+		sys.field("Description", AT_Locale, "", doc="The subsystem's description.");
+		sys.field("BaseColor", AT_Color, "", doc="Color of the hexagon base/floor that the subsystem is drawn on.");
+		sys.field("TypeColor", AT_Color, "", doc="Color contribution of this subsystem to the ship's overall type color.");
+		sys.field("Elevation", AT_Integer, "0", doc="Elevation of this subsystem's hexes in the isometric hex view.");
+		sys.field("Tags", AT_Custom, "", doc="A list of comma-separated arbitrary tags that the subsystem is assigned with.");
+		sys.field("Hull", AT_Custom, "", doc="List of comma-separated hull types that this subsystem can be used on.");
+		sys.field("EvaluationOrder", AT_Integer, "0", doc="Subsystems with lower evaluation orders are executed before higher ones. This is significant for the order in which modifiers and asserts are executed.");
+		sys.field("DamageOrder", AT_Integer, "0", doc="Indicates the order in which this subsystem's GlobalDamage events are run. This does not have any effect on normal hex-based damage, only on globaldamage interception steps that happen beforehand.");
+		sys.field("OnCheckErrors", AT_Custom, "", doc="Script function that is used to check the subsystem for design errors when placed.");
+
+		vars(sys);
+		sysInner(sys);
+		effBlock(sys);
+
+		auto@ templ = block("Template", doc="All blocks inside this template are added to subsystems that match the template's condition.");
+		templ.identifierLimit = false;
+		sysInner(templ);
+		effBlock(templ);
+
+		auto@ defaults = templ.block("Defaults", doc="Default values for variables that can be overwritten.");
+		defaults.hasIdentifier = false;
+		vars(defaults);
+	}
+
+	void sysInner(BlockDef@ sys) {
+		sys.field("AddShipModifier", AT_Custom, "", repeatable=true, doc="If this subsystem is present, the specified modifier is applied to every subsystem on the ship with a higher evaluation order.");
+		sys.field("AddPostModifier", AT_Custom, "", repeatable=true, doc="This modifier is added to this subsystem after all other subsystems have been evaluated.");
+		sys.field("AddAdjacentModifier", AT_Custom, "", repeatable=true, doc="If this subsystem is present, the specified modifier is applied to every hex adjacent to this hex.");
+
+		auto@ modif = sys.block("Modifier", doc="A modifier function that can be applied to this subsystem.");
+		modif.identifierLimit = false;
+		modif.field("Stage", AT_Integer, "", doc="Sets a static evaluation stage for this modifier. Not needed in most cases.");
+		vars(modif);
+
+		auto@ modu = sys.block("Module", doc="Every hex on the subsystem has exactly one module on it. Modules are parts of the subsystem that can behave differently, ie the default module, modifiers, or the core/turret module.",
+				hookType="subsystem_effects::SubsystemHook", hookModule="subsystem_effects");
+		modu.hookPrefix = "Hook: ";
+		modu.field("Name", AT_Locale, "", doc="Name of the module.");
+		modu.field("Description", AT_Locale, "", doc="Description of the module.");
+		modu.field("Color", AT_Color, "", doc="The module's color.");
+		modu.field("Required", AT_Boolean, "False", doc="Whether every subsystem is required to have at least one of these modules. 'Core' modules are implied to be required.");
+		modu.field("Unique", AT_Boolean, "False", doc="Whether subsystems can only have up to one of these modules in them. 'Core' modules are implied to be unique.");
+		modu.field("Vital", AT_Boolean, "False", doc="Whether subsystems are deactivated when a module of this type is destroyed. 'Core' modules are implied to be vital.");
+		modu.field("DefaultUnlock", AT_Boolean, "False", doc="Whether empires have access to this module by default. 'Core' and 'Default' modules are implied to be unlocked by default.");
+		modu.field("Sprite", AT_Sprite, "", doc="Sprite that is rendered on the isometric design view.");
+		modu.field("DrawMode", AT_Integer, "0", doc="The way the sprite is drawn on the design. 0 indicates a singular sprite, 1 is used for rotatable turrets.");
+		modu.field("OnEnable", AT_Custom, "", doc="Script function that is called when this module gets enabled.");
+		modu.field("OnDisable", AT_Custom, "", doc="Script function that is called when this module gets disabled.");
+		modu.field("AddModifier", AT_Custom, "", repeatable=true, doc="If this module is present in a subsystem, the specified modifier is added to the entire subsystem.");
+		modu.field("AddUniqueModifier", AT_Custom, "", repeatable=true, doc="If this module is present in a subsystem, the specified modifier is added to the entire subsystem, but only once, regardless of the amount of modules.");
+		modu.field("AddAdjacentModifier", AT_Custom, "", repeatable=true, doc="The specified modifier is applied to every hex adjacent to the module's hex.");
+
+		vars(modu);
+		effBlock(modu);
+		asserts(modu);
+
+		auto@ efftr = sys.block("Effector", doc="An effector that can trigger projectiles on objects.");
+		vals(efftr);
+
+		asserts(sys);
+	}
+
+	void asserts(BlockDef@ sys) {
+		auto@ ass = sys.block("Assert", doc="A criterion that must be satisfied for the subsystem.");
+		ass.identifierLimit = false;
+		ass.field("Unique", AT_Boolean, "False", doc="Whether this criterion should only be checked once per ship.");
+		ass.field("Fatal", AT_Boolean, "True", doc="Whether failing this criterion makes the design invalid and unable to be saved.");
+		ass.field("Message", AT_Locale, "", doc="The message for failing the criterion.");
+
+		auto@ req = sys.block("Requires", doc="A list of ship variable requirements.");
+		vals(req);
+		req.hasIdentifier = false;
+
+		auto@ prov = sys.block("Provides", doc="A list of ship variable provisions.");
+		vals(prov);
+		prov.hasIdentifier = false;
+	}
+
+	void effBlock(BlockDef@ sys) {
+		auto@ eff = sys.block("Effect", doc="An effect that is active while the subsystem or module is.");
+		vals(eff);
+	}
+
+	void vars(BlockDef@ sys) {
+		sys.field("Variable", AT_VariableDef, "", repeatable=true, doc="An arbitrary variable that can store data about this subsystem and be used.")
+			.setCondition(VariableCondition()).setFullLine(true);
+	}
+
+	void vals(BlockDef@ blk) {
+		blk.field("Value", AT_ValueDef, "", repeatable=true, doc="A filled in value for a particular block.")
+			.setCondition(ValueCondition()).setFullLine(true);
+	}
+
+	void onChange() {
+		loadCompletions(subsysCompletions, "data/subsystems", "Subsystem");
+	}
+};
+
+class EffectorFile : FileDef {
+	array<string> efficiencyModes = {"Normal", "Reload Only", "Duration Only", "Reload Partial", "Duration Partial"};
+	array<string> physicalTypes = {"Instant", "Projectile", "Missile", "Beam", "Aimed Missile"};
+
+	EffectorFile() {
+		auto@ efftr = block("Effector", doc="An effector that can trigger projectiles on objects.");
+		field("Value", AT_Custom, "", repeatable=true, doc="A value that can be passed in by the subsystem using the effector. A default value can also be specified.");
+		field("Range", AT_Custom, "", doc="Formula based on values for the range at which this effector can activate.");
+		field("Lifetime", AT_Custom, "", doc="Formula based on values for the lifetime of the projectile.");
+		field("Speed", AT_Custom, "", doc="Formula based on values for the speed of the projectile.");
+		field("Tracking", AT_Custom, "", doc="Formula based on values for the projectile/turret's tracking speed.");
+		field("Spread", AT_Custom, "", doc="Formula based on values for the spread angle of the turret. A higher spread means a more inaccurate weapon.");
+		field("CapTarget", AT_Custom, "", doc="Formula based on values for the amount of times to fire before switching targets.");
+		field("FireArc", AT_Custom, "", doc="Formula based on values for the firing arc angle of the turret, expressed in radians.");
+		field("TargetTolerance", AT_Custom, "", doc="Formula based on values for how far from the firing arc turrets will target enemies, expressed in radians.");
+		field("FireTolerance", AT_Custom, "", doc="Formula based on values for how far from the firing arc turrets will fire at enemies, expressed in radians.");
+		field("TargetAlgorithm", AT_Custom, "", doc="Algorithm used for targeting nearby enemies. Should be set to 'SingleTarget' almost all of the time.");
+		field("Activation", AT_Custom, "", doc="Function that governs the activation cycle of the turret.");
+		field("OnTrigger", AT_Custom, "", doc="Function that can be called when the effector triggers.");
+		field("CanTarget", AT_Custom, "", doc="Expression that determines whether this turret can fire at a particular object.");
+		field("AutoTarget", AT_Custom, "", doc="Expression that determines whether this turret should automatically target a particular object when in range.");
+		field("Physical", AT_Boolean, "True", doc="Whether the projectile should be physically simulated and can miss, or should always hits its intended target.");
+		field("EfficiencyMode", AT_Selection, "Normal", doc="The way increased or decreased efficiency effects the turret's behaviour. When set to reload, the reload time of the turret is affected by efficiency. When set to duration, the duration of a beam is affected by efficiency. When set to partial, only part of the increased efficiency is used this way, and the rest is passed along to the effect (to, for example, deal increased damage).")
+			.setOptions(efficiencyModes);
+		field("PhysicalType", AT_Selection, "Instant", doc="The type of projectile that is emitted by this effector.")
+			.setOptions(physicalTypes);
+		field("PhysicalSize", AT_Decimal, "1.0", doc="The relative physical size of the projectile.");
+		gfx(efftr);
+
+		auto@ skin = efftr.block("Skin", doc="A secondary graphical skin for this effector that can be selected from a subsystem or from the empire's weapon skin.");
+		skin.field("Inherit", AT_Custom, "", doc="Copy over the graphical values from a different non-default skin.").setPriority(-100);
+		gfx(skin);
+
+		auto@ eff = efftr.block("Effect", doc="An effect that is activated on the target object when hit. Only one is allowed per effector.");
+		eff.field("Value", AT_ValueDef, "", repeatable=true, doc="A filled in value that is passed to the effect.")
+			.setCondition(ValueCondition()).setFullLine(true);
+	}
+
+	array<string> gfxTypes = {"Sprite", "Line", "Beam"};
+	void gfx(BlockDef@ b) {
+		b.field("GfxType", AT_Selection, "Sprite", doc="The type of graphics associated with the projectile.")
+			.setOptions(gfxTypes);
+		b.field("GfxSize", AT_Decimal, "1.0", doc="The relative size of the projectile graphics.");
+		b.field("Trail", AT_Material, "", doc="The material for the graphics trail.");
+		b.field("TrailCol", AT_Custom, "", doc="The color(s) for the graphics trail.");
+		b.field("Color", AT_Color, "", doc="The override color for the projectile.");
+		b.field("Color", AT_Color, "", doc="The override color for the projectile.");
+		b.field("ImpactGfx", AT_Custom, "", doc="Particle system to play when the projectile impacts.");
+		b.field("Material", AT_Material, "", doc="Material to display the projectile with.");
+		b.field("ImpactSfx", AT_Custom, "", doc="Sound effect to play when the projectile impacts.");
+		b.field("FireSfx", AT_Custom, "", repeatable=true, doc="Sound effect to play when the turret fires. When multiple FireSfx entries are specified, one is chosen randomly every time the weapon fires.");
+		b.field("FirePitchVariance", AT_Decimal, "0", doc="Variance in the fire sound's pitch.");
+	}
+};
+
+class MaterialFile : FileDef {
+	array<string> sheetModes = {"Horizontal", "Vertical"};
+	MaterialFile() {
+		defaultBlock.doc = "[font=Subtitle]Note: Changes to material files will not be updated on other pages until the game is restarted.[/font]";
+
+		auto@ mat = block("Material", doc="A material that can be rendered on models or in the GUI.");
+		mat.closeDefault = true;
+		common(mat);
+
+		auto@ sheet = block("SpriteSheet", doc="A material that consists of multiple sprites laid out in a spritesheet.");
+		sheet.closeDefault = true;
+		sheet.field("Size", AT_Custom, "", doc="Size of each individual sprite in the sheet, expressed as 'width,height'.");
+		sheet.field("Spacing", AT_Integer, "", doc="Spacing in front of each individual sprite in the sheet, in pixels.");
+		sheet.field("Mode", AT_Selection, "Horizontal", doc="Whether the spritesheet should be numbered left to right first (horizontal), or top to bottom first (vertical).")
+			.setOptions(sheetModes);
+		common(sheet);
+
+		auto@ grp = block("MaterialGroup", doc="A group of materials automatically generated from all images in a folder, according to a template.");
+		grp.closeDefault = true;
+		grp.field("Folder", AT_File, "", doc="Path to the folder that images are taken from.");
+		grp.field("Prefix", AT_Custom, "", doc="Prefix added to the filenames in the folder to make the names of the related materials.");
+		grp.field("Template", AT_Custom, "", doc="A material declared earlier in the file that materials generated from the folder are based on.");
+	}
+
+	array<string> depthTest = {"", "Never", "Less", "LessEqual", "Equal", "GreaterEqual", "Greater", "Always", "NoDepthTest"};
+	array<string> culling = {"", "None", "Front", "Back", "Both"};
+	array<string> wrapModes = {"", "Repeat", "Clamp", "ClampEdge", "Mirror"};
+	array<string> filters = {"", "Linear", "Nearest"};
+	array<string> modes = {"", "Fill", "Line"};
+	array<string> blends = {"", "Alpha", "Solid", "Add", "Overlay", "Font"};
+	void common(BlockDef@ b) {
+		b.field("Inherit", AT_Custom, "", doc="Copy material render data from a builtin material or one defined earlier in the file.\n\nCommonly used to inherit the Image2D engine material, indicating that a material is intended for GUI use.").setPriority(-100);
+
+		b.field("LoadPriority", AT_Custom, "", doc="Indicates at what stage of the game the texture should be ensured to be loaded. Can be set to a number (higher is earlier), or one of 'Critical', 'Menu', 'Game', 'High', or 'Low'. Textures with a priority lower than 'Game' will be streamed while the game is already running.").setPriority(-10);
+
+		for(uint i = 1; i <= 6; ++i) {
+			string key = "Texture";
+			if(i != 1)
+				key += i;
+			b.field(key, AT_File, "", doc="The file location of a png texture that this material renders with.").setPriority(10);
+		}
+
+		b.field("Shader", AT_Custom, "", doc="Name of the shader to use for rendering this material.");
+		b.field("DepthWrite", AT_Boolean, "True", doc="Whether the material should write to the depth buffer.");
+		b.field("DepthTest", AT_Selection, "", doc="How the material should test against the depth buffer.")
+			.setOptions(depthTest);
+		b.field("Culling", AT_Selection, "", doc="How the material should apply face culling.")
+			.setOptions(culling);
+		b.field("Lighting", AT_Boolean, "True", doc="Whether the material should use lighting.");
+		b.field("NormalizeNormals", AT_Boolean, "False", doc="Whether to normalize the normal values when this material is rendered.");
+		b.field("Shininess", AT_Decimal, "", doc="Shininess factor for lighting when this material is rendered.");
+		b.field("WrapVertical", AT_Selection, "", doc="What behaviour should be used for wrapping texture lookups beyond the vertical edges of the material.")
+			.setOptions(wrapModes);
+		b.field("WrapHorizontal", AT_Selection, "", doc="What behaviour should be used for wrapping texture lookups beyond the horizontal edges of the material.")
+			.setOptions(wrapModes);
+		b.field("FilterMin", AT_Selection, "", doc="When the texture is scaled down, which texture filter method to use.")
+			.setOptions(filters);
+		b.field("FilterMag", AT_Selection, "", doc="When the texture is scaled up, which texture filter method to use.")
+			.setOptions(filters);
+		b.field("DrawMode", AT_Selection, "", doc="The mode that the texture draws on top of a model with.")
+			.setOptions(modes);
+		b.field("Blend", AT_Selection, "", doc="How the material blends with things rendered behind it.")
+			.setOptions(blends);
+		b.field("Alpha", AT_Boolean, "False", doc="Whether the material should use alpha rendering.");
+		b.field("Diffuse", AT_Color, "", doc="Color to use for the material's diffuse lighting.");
+		b.field("Specular", AT_Color, "", doc="Color to use for the material's specular lighting.");
+	}
+};
+
+class SoundFile : FileDef {
+	SoundFile() {
+		auto@ snd = block("Sound", doc="A sound effect that can be played in the game.");
+		snd.closeDefault = true;
+		common(snd);
+
+		auto@ strm = block("Stream", doc="A sound effect that is streamed as it is played. Should be used for longer sound effects.");
+		strm.closeDefault = true;
+		common(strm);
+	}
+
+	void common(BlockDef@ b) {
+		field("File", AT_File, "", doc="Path to the .ogg file that contains the sound.");
+		field("Volume", AT_Decimal, "1", doc="Relative volume to play the sound at.");
+	}
+};
+
+class EventFile : FileDef {
+	EventFile() {
+		localeFile = "random_events.txt";
+		auto@ evt = block("Event", doc="A random event that can be triggered in game when conditions are met.",
+				hookType="random_events::IRandomEventHook", hookModule="event_effects").checkDuplicates(eventCompletions);
+		evt.field("Name", AT_Locale, "", doc="Name of the random event.");
+		evt.field("Text", AT_Locale, "", doc="Text and narrative of the random event.");
+		evt.field("Frequency", AT_Decimal, "1.0", doc="Rate at which this random event occurs relative to other random events.");
+		evt.field("Timer", AT_Decimal, "180", doc="Time in seconds that the choice is available. If it runs out, the first available Default option is chosen automatically.");
+		evt.field("Unique", AT_Boolean, "True", doc="Unique events can only occur once per game.");
+		evt.field("Target", AT_TargetSpec, "", repeatable=true, doc="A type of target this event triggers on.");
+
+		auto@ opt = evt.block("Option", doc="An option that can be chosen for this event.",
+				hookType="random_events::IRandomOptionHook", hookModule="event_effects");
+		opt.field("Text", AT_Locale, "", doc="Text and narrative of the option.");
+		opt.field("Icon", AT_Sprite, "", doc="Icon used to represent the option.");
+		opt.field("Safe", AT_Boolean, "True", doc="Whether this option is safe and cannot result in horrible unwanted consequences. Mainly used by the AI for decision making.");
+		opt.field("Default", AT_Boolean, "False", doc="When the timer runs out on a random event, the first available option that has Default set is chosen.");
+
+		auto@ res = opt.block("Result", doc="One particular result that may occur. The chance specified is the chance of this result happening rather than any other result.",
+				hookType="random_events::IRandomOptionHook", hookModule="event_effects");
+
+		res.block("On", doc="Hooks inside an On block are applied on the target specified by the On block, instead of only on the event's owning empire.",
+				hookType="random_events::IRandomOptionHook", hookModule="event_effects");
+		opt.block("On", doc="Hooks inside an On block are applied on the target specified by the On block, instead of only on the event's owning empire.",
+				hookType="random_events::IRandomOptionHook", hookModule="event_effects");
+	}
+
+	void onChange() {
+		loadCompletions(eventCompletions, "data/random_events", "Event");
+	}
+};
+
+class CargoFile : FileDef {
+	CargoFile() {
+		localeFile = "resources.txt";
+		block("Cargo", doc="A type of cargo that can be stored and moved.");
+			field("Name", AT_Locale, "", doc="Name of the cargo type.");
+			field("Description", AT_Locale, "", doc="Description of the cargo type.");
+			field("Icon", AT_Sprite, "", doc="Icon used to display the cargo.");
+			field("Color", AT_Color, "", doc="Color used to display the cargo.");
+			field("Storage Size", AT_Decimal, "1.0", doc="Size of one unit of this cargo in cargo storage.");
+	}
+
+	void onChange() {
+		loadCompletions(cargoCompletions, "data/cargo", "Cargo");
+	}
+};

--- a/OpenSR/scripts/gui/editor/defs.as
+++ b/OpenSR/scripts/gui/editor/defs.as
@@ -193,6 +193,7 @@ class StatusFile : FileDef {
 			field("Unique", AT_Boolean, "False", doc="Unique statuses indicate that the status cannot affect an object more than once, so should not be given a stack count display.");
 			field("Collapses", AT_Boolean, "False", doc="A status that collapses will show a stack count instead of being a separate status for each instance. The status hooks are responsible for dealing with stack counts on an individual basis.");
 			field("Visible To", AT_Selection, "Everybody", doc="Which empires the status can be seen by when looking at the object.").setOptions(visibilities);
+			field("Show Duration", AT_Boolean, "False", doc="The duration of instances of this status should be visible to end users. (NB: Only implemented for status boxes on ships)");
 	}
 
 	void onChange() {

--- a/OpenSR/scripts/server/components/Mover.as
+++ b/OpenSR/scripts/server/components/Mover.as
@@ -1,0 +1,1551 @@
+import oddity_navigation;
+from regions.regions import getRegion;
+import saving;
+import ftl;
+
+const double straighDot = 0.99999;
+
+//Rotation rate in radians/s
+const double shipRotSpeed = 0.1;
+const double SQRT_2 = sqrt(2.0);
+
+double lowerQuadratic(double a, double b, double c) {
+	double d = sqrt(b*b - 4.0 * a * c);
+	if(d != d)
+		return 10000.0;
+	//double r1 = (-b + d) / (2.0 * a);
+	double r2 = (-b - d) / (2.0 * a);
+	if(r2 > 0.0)
+		return r2;
+	else
+		return 10000.0;
+}
+
+double timeToTarg(double a, const vec3d& offset, const vec3d& relVel) {
+	double dist = offset.length, speed = relVel.length;
+	if(speed < 0.05) {
+		return sqrt(4.0 * dist / a);
+	}
+
+	double velDot = 1.0;
+	if(dist > 0.001)
+		velDot = relVel.dot(offset) / (dist * speed);
+	if(velDot > straighDot) {
+		//We must accelerate up to the target speed before hitting the point
+
+		// d = 1/2 a * t^2 (where t = v/a)
+		double accelDist = 0.5 * speed * speed / a;
+
+		if(accelDist > dist) {
+			//return (speed / a) + sqrt(4.0 * (accelDist - dist) / a);
+			//return (speed / a) + (accelDist - dist) / speed;
+
+			return lowerQuadratic(-a, 2.0 * speed, dist - accelDist);
+		}
+		else {
+			//We have enough distance
+			//Accelerate until we must decelerate
+			double totalTime = sqrt(4.0 * (dist - accelDist) / a);
+			return totalTime + (speed / a);
+		}
+	}
+	else if(velDot < -straighDot) {
+		double deccelTime = speed / a;
+		double deccelDist = deccelTime * speed * 0.5;
+
+		//We either need to slow down, or accelerate to a maximum velocity
+		if(deccelDist < dist) {
+			double totalTime = sqrt(4.0 * (deccelDist + dist) / a);
+			return totalTime - (speed / a);
+		}
+		else {
+			return deccelTime + sqrt(4.0 * (deccelDist - dist) / a);
+		}
+	}
+	else {
+		vec3d linearVel = offset.normalized(speed * velDot);
+		vec3d latVel = relVel - linearVel;
+		vec3d zero;
+
+		double aToward = 0.7;
+
+		double rangeLow = 0.0001, rangeHigh = 0.9999;
+		double t = 0, leastErr = 99999999.0;
+		for(uint i = 0; i < 15; ++i) {
+			double aLat = sqrt(1.0 - (aToward * aToward));
+
+			double tToward = timeToTarg(aToward * a, offset, linearVel);
+			double tLat = timeToTarg(aLat * a, zero, latVel);
+
+			double err = abs(tToward - tLat);
+			if(err < leastErr) {
+				leastErr = err;
+				t = (tToward + tLat) * 0.5;
+			}
+
+			if(err < 0.02)
+				break;
+			else if(tToward > tLat) {
+				rangeLow = aToward;
+				aToward = (rangeLow + rangeHigh) * 0.5;
+			}
+			else {
+				rangeHigh = aToward;
+				aToward = (rangeLow + rangeHigh) * 0.5;
+			}
+		}
+
+		return t;
+	}
+}
+
+vec3d accToGoal(double a, double& maxTime, const vec3d& offset, const vec3d& relVel) {
+	double dist = offset.length, speed = relVel.length;
+
+	if(speed < 0.05) {
+		//Accelerates for half the time, decelerates for half the time
+		maxTime = sqrt(4.0 * dist / a) * 0.5;
+		return offset.normalized(a);
+	}
+	else {
+		double velDot = 1.0;
+		if(dist > 0.001)
+			velDot = relVel.dot(offset) / (dist * speed);
+		if(velDot > straighDot) {
+			//We must accelerate up to the target speed before hitting the point
+
+			// d = 1/2 a * t^2 (where t = v/a)
+			double accelDist = 0.5 * speed * speed / a;
+
+			if(accelDist > dist) {
+				//error(accelDist + " vs " + dist);
+				//maxTime = sqrt(4.0 * (accelDist - dist) / a) * 0.5;
+				//return offset.normalized(-a);
+				//maxTime = (accelDist - dist) / speed;
+				//return vec3d();
+				maxTime = lowerQuadratic(-a, 2.0 * speed, dist - 0.5 * accelDist);
+				return offset.normalized(a);
+			}
+			else {
+				//We have enough distance
+				//Accelerate until we must decelerate
+				maxTime = speed / a;
+				return offset.normalized(a);
+			}
+		}
+		else if(velDot < -straighDot) {
+			double deccelTime = speed / a;
+			double deccelDist = deccelTime * speed * 0.5;
+			if(deccelDist < dist) {
+				//Determine our time remaining based on the original null-vel curve
+				double totalTime = sqrt(4.0 * (deccelDist + dist) / a);
+				maxTime = (totalTime * 0.5) - (speed / a);
+				return offset.normalized(a);
+			}
+			else {
+				maxTime = speed / a;
+				return relVel.normalized(a);
+			}
+		}
+		else {
+			vec3d linearVel = offset.normalized(speed * velDot);
+			vec3d latVel = relVel - linearVel;
+			vec3d zero;
+
+			double rangeLow = 0.0001, rangeHigh = 0.9999;
+			double aToward = 0.7;
+			double aLat;
+
+			double t = 0, leastErr = 999999999.0;
+
+			for(uint i = 0; i < 15; ++i) {
+				aLat = sqrt(1.0 - (aToward * aToward));
+
+				double tToward = timeToTarg(aToward * a, offset, linearVel);
+				//double tLat = timeToTarg(aLat * a, zero, latVel);
+
+				double tLat = latVel.length / (aLat * a);
+				double latDist = latVel.length * tLat * 0.5;
+				tLat += sqrt(4.0 * latDist / (aLat * a));
+
+				double err = abs(tToward - tLat);
+				if(err < leastErr) {
+					leastErr = err;
+					t = (tToward + tLat) * 0.5;
+				}
+
+				if(err < 0.02)
+					break;
+				else if(tToward > tLat) {
+					rangeLow = aToward;
+					aToward = (rangeLow + rangeHigh) * 0.5;
+				}
+				else {
+					rangeHigh = aToward;
+					aToward = (rangeLow + rangeHigh) * 0.5;
+				}
+			}
+			aLat = sqrt(1.0 - (aToward * aToward));
+
+			double maxT1 = 0, maxT2 = 0;
+
+			vec3d linAcc = accToGoal(aToward * a, maxT1, offset, linearVel);
+			//vec3d latAcc = accToGoal(aLat * a, maxT2, zero, latVel);
+			vec3d latAcc = latVel.normalize(aLat * a); maxT2 = latVel.length / (aLat * a);
+
+			maxTime = min(maxT1, maxT2);
+			return latAcc + linAcc;
+		}
+	}
+}
+
+tidy class Mover : Component_Mover, Savable {
+	Object@ target;
+	vec3d destination;
+	quaterniond prevFormationDest;
+	quaterniond targRot;
+	quaterniond targFacing;
+	quaterniond combatFacing;
+	vec3d compDestination;
+	bool inCombat = false;
+	double targDist = 0;
+	int prevPathId = 0;
+	array<PathNode@>@ path;
+
+	Object@ lockTo;
+	bool isLocked = false;
+	vec3d lockOffset;
+	float rotSpeed = shipRotSpeed;
+	bool vectorMovement = false;
+	bool fleetRelative = true;
+
+	const Object@ colliding;
+
+	double accel = 1.0;
+	double accelBonus = 0;
+	bool moving = false;
+	bool rotating = false;
+	bool moverDelta = false;
+	bool posDelta = false;
+	bool facingDelta = false;
+	int moveID = 0;
+	int syncedID = 0;
+
+	bool FTL = false;
+	double FTLSpeed = 1.0;
+
+	Mover() {
+	}
+
+	void load(SaveFile& data) {
+		data >> target;
+		data >> destination;
+		data >> accel;
+		if(data >= SV_0100)
+			data >> accelBonus;
+		data >> moving;
+		data >> rotating;
+		data >> lockTo;
+		data >> isLocked;
+		data >> lockOffset;
+		data >> moveID;
+		data >> FTL;
+		data >> FTLSpeed;
+		data >> targDist;
+		data >> combatFacing;
+		data >> targFacing;
+		data >> inCombat;
+		if(data >= SV_0126)
+			data >> vectorMovement;
+		if(data >= SV_0048)
+			data >> rotSpeed;
+		if(data >= SV_0054)
+			data >> fleetRelative;
+
+		if(data >= SV_0009) {
+			uint cnt = 0;
+			data >> cnt;
+			if(cnt > 0) {
+				@path = array<PathNode@>(cnt);
+				for(uint i = 0; i < cnt; ++i) {
+					@path[i] = PathNode();
+					data >> path[i];
+				}
+			}
+		}
+
+		if(data >= SV_0067)
+			data >> prevPathId;
+	}
+
+	void save(SaveFile& data) {
+		data << target;
+		data << destination;
+		data << accel;
+		data << accelBonus;
+		data << moving;
+		data << rotating;
+		data << lockTo;
+		data << isLocked;
+		data << lockOffset;
+		data << moveID;
+		data << FTL;
+		data << FTLSpeed;
+		data << targDist;
+		data << combatFacing;
+		data << targFacing;
+		data << inCombat;
+		data << vectorMovement;
+		data << rotSpeed;
+		data << fleetRelative;
+
+		uint cnt = path is null ? 0 : path.length;
+		data << cnt;
+		for(uint i = 0; i < cnt; ++i)
+			data << path[i];
+		data << prevPathId;
+	}
+
+	void destroy() {
+		@target = null;
+	}
+
+	Object@ getLockedOrbit(bool requireLock = true) {
+		if(requireLock && !isLocked)
+			return null;
+		return lockTo;
+	}
+
+	bool hasLockedOrbit(bool requireLock = true) {
+		if(requireLock && !isLocked)
+			return false;
+		return lockTo !is null;
+	}
+
+	bool isLockedOrbit(Object@ at, bool requireLock = true) {
+		if(requireLock && !isLocked)
+			return false;
+		if(lockTo is at)
+			return true;
+		return false;
+	}
+
+	Object@ getAroundLockedOrbit(Object& obj) {
+		if(lockTo is null)
+			return null;
+		if(lockTo.isPlanet) {
+			double maxDist = cast<Planet>(lockTo).OrbitSize;
+			if(obj.position.distanceToSQ(lockTo.position) > maxDist * maxDist)
+				return null;
+		}
+		return lockTo;
+	}
+
+	double get_ftlSpeed() {
+		return FTLSpeed;
+	}
+
+	void set_ftlSpeed(double value) {
+		if(FTLSpeed == value)
+			return;
+		FTLSpeed = value;
+		moverDelta = true;
+	}
+
+	bool FTLTo(Object& obj, vec3d target, double speed, int& id) {
+		if(id > 0 && id == moveID)
+			return !FTL;
+		if(FTL)
+			return false;
+		moveTo(obj, target, id, false);
+		FTL = true;
+		FTLSpeed = max(speed, 1.0);
+		return false;
+	}
+
+	void FTLTo(Object& obj, vec3d target, double speed) {
+		if(FTL)
+			return;
+		int id = -1;
+		moveTo(obj, target, id, false);
+		FTL = true;
+		FTLSpeed = max(speed, 1.0);
+	}
+
+	void FTLDrop(Object& obj) {
+		if(!FTL)
+			return;
+		obj.velocity = vec3d();
+		obj.acceleration = vec3d();
+		FTL = false;
+		FTLSpeed = 0;
+		stopMoving(obj);
+		moverDelta = true;
+		posDelta = true;
+	}
+
+	bool get_isColliding() const {
+		return colliding !is null;
+	}
+
+	bool get_inFTL() const {
+		return FTL;
+	}
+
+	bool get_isMoving(const Object& obj) const {
+		return moving || rotating || FTL;
+	}
+
+	vec3d get_internalDestination() const {
+		return destination;
+	}
+
+	vec3d get_computedDestination() const {
+		return compDestination;
+	}
+
+	vec3d get_moveDestination(const Object& obj) const {
+		if(target !is null) {
+			vec3d dir = (target.position - obj.position);
+			return obj.position + dir.normalized(dir.length - targDist);
+		}
+		if(lockTo !is null)
+			return lockTo.position + lockOffset;
+		if(obj.hasSupportAI) {
+			const Ship@ ship = cast<const Ship>(obj);
+			Object@ leader = ship.Leader;
+
+			if(leader !is null) {
+					Ship@ leaderShip = cast<Ship>(leader);
+					quaterniond formationFacing;
+					if(leaderShip !is null)
+						formationFacing = leaderShip.formationDest;
+
+					if(fleetRelative)
+						return leader.position + (formationFacing * ship.formationDest.xyz);
+					else
+						return leader.position + destination;
+			}
+		}
+		return destination;
+	}
+
+	bool get_hasMovePath() const {
+		return path !is null && path.length > 0;
+	}
+
+	bool get_hasMovePortal() {
+		return path !is null && path.length > 0 && path[0].pathEntry !is null;
+	}
+
+	vec3d getMovePortal() {
+		if(path is null || path.length == 0)
+			return vec3d();
+		return path[0].pathOut();
+	}
+
+	void getMovePath(const Object& obj) const {
+		if(path is null)
+			return;
+
+		Object@ prev;
+		for(uint i = 0, cnt = path.length; i < cnt; ++i) {
+			auto@ node = path[i];
+			if(node.pathEntry !is prev)
+				yield(node.pathEntry);
+			if(node.pathExit !is null)
+				yield(node.pathExit);
+		}
+	}
+
+	double get_maxAcceleration() const {
+		return accel;
+	}
+
+	void set_rotationSpeed(float amt) {
+		if(rotSpeed != amt) {
+			rotSpeed = amt;
+			moverDelta = true;
+		}
+	}
+
+	void set_hasVectorMovement(bool value) {
+		if(vectorMovement != value) {
+			vectorMovement = value;
+			moverDelta = true;
+		}
+	}
+
+	void set_maxAcceleration(Object& obj, double Accel) {
+		if(accel != Accel) {
+			moverDelta = true;
+			accel = Accel + accelBonus;
+		}
+	}
+
+	void modAccelerationBonus(double mod) {
+		accel += mod;
+		accelBonus += mod;
+		moverDelta = true;
+	}
+
+	bool get_leaderLock() {
+		return fleetRelative;
+	}
+
+	void set_leaderLock(bool doLock) {
+		if(fleetRelative != doLock) {
+			fleetRelative = doLock;
+			//If we're changing to a locked state, we need a delta (other steps are responsible for this when a lock is released)
+			if(doLock)
+				moverDelta = true;
+		}
+	}
+
+	void impulse(Object& obj, vec3d ForceSeconds) {
+		obj.velocity += ForceSeconds;
+		moving = true;
+		moverDelta = true;
+		posDelta = true;
+
+		if(obj.hasOrbit && obj.inOrbit)
+			obj.stopOrbit();
+	}
+
+	void rotate(Object& obj, quaterniond rot) {
+		obj.rotation *= rot;
+		rotating = true;
+		moverDelta = true;
+	}
+
+	double timeToTarget(Object& obj, double a, const vec3d& point, const vec3d& velocity) {
+		//NOTE: The engine implements an identical implementation of timeToTarg for performance reasons
+		//return timeToTarg(a, point - obj.position, velocity - obj.velocity);
+		return newtonArrivalTime(a, point - obj.position, velocity - obj.velocity);
+	}
+
+	void speedBoost(Object& obj, double amount) {
+		//Note to self: try to keep any cleaver-like objects away from
+		//Reaper for a while after this code gets committed. Maybe go into
+		//hiding a few years.
+
+		if(accel == 0)
+			return;
+		vec3d acc = obj.acceleration.normalized();
+		vec3d dist = get_moveDestination(obj) - obj.position;;
+		double distLen = dist.length;
+		double velLen = obj.velocity.length;
+		if(amount > 0 && distLen < velLen * 2.0)
+			return;
+		moverDelta = true;
+		dist /= distLen;
+
+		if(amount < 0) {
+			if(acc.angleDistance(dist) < pi) {
+				//Remove some of our velocity-to-target.
+				// The move algorithm will compensate, since we're
+				// still accelerating towards it.
+				obj.velocity.length = velLen + amount;
+			}
+			else {
+				//We're slowing down. Don't slow down below what would be
+				//a sane-ish speed for this ship *ducks*.
+				double sane = min(velLen, distLen / accel);
+				obj.velocity.length = max(sane, velLen + amount);
+			}
+		}
+		else {
+			if(acc.angleDistance(dist) < pi) {
+				//Fucking full speed ahead. Who gives a shit.
+				obj.velocity += dist * amount;
+			}
+		}
+	}
+
+	vec3d accelToGoal(Object& obj, double a, double& maxTime, const vec3d& point, const vec3d& velocity) {
+		vec3d offset = point - obj.position;
+		vec3d relVel = velocity - obj.velocity;
+		return accToGoal(a, maxTime, offset, relVel);
+	}
+
+	double moverTick(Object& obj, double time) {
+		if(time <= 0)
+			return 0.1;
+
+		if(!moving && !inFTL && obj.hasOrbit && obj.inOrbit) {
+			obj.orbitTick(time);
+			return 0.25;
+		}
+
+		//Push away from nearby objects
+		if(!obj.isPlanet && !obj.noCollide && (!obj.hasSupportAI || !obj.isDetached)) {
+			if(colliding is null) {
+				const Object@ nearest;
+				double dist = 0;
+				double myRadius = obj.radius;
+				for(int i = 0; i < TARGET_COUNT; ++i) {
+					const Object@ other = obj.targets[i];
+					if(other is obj || !other.isPhysical || other.noCollide)
+						continue;
+					//Only push from things larger than me
+					if(other.radius < myRadius && !other.isPlanet && !other.isStar)
+						continue;
+					vec3d off = obj.position - other.position;
+					double d = off.lengthSQ;
+					if(d <= (obj.radius + other.radius) * (obj.radius + other.radius)) {
+						off += random3d(0.1); off.normalize();
+						obj.position += off * min(time * other.radius * 0.5, d - other.radius + obj.radius);
+						@colliding = other;
+						break;
+					}
+					else if(nearest is null || d < dist) {
+						@nearest = other;
+						dist = d;
+					}
+				}
+
+				if(nearest !is null && colliding is null) {
+					for(int i = 0; i < TARGET_COUNT; ++i) {
+						const Object@ other = nearest.targets[i];
+						if(other is obj || !other.isPhysical || other.noCollide)
+							continue;
+						//Only push from things larger than me
+						if(other.radius < myRadius && !other.isPlanet && !other.isStar)
+							continue;
+						vec3d off = obj.position - other.position;
+						double d = off.lengthSQ;
+						if(d <= (obj.radius + other.radius) * (obj.radius + other.radius)) {
+							off += random3d(0.1); off.normalize();
+							obj.position += off * min(time * other.radius * 0.5, d - other.radius + obj.radius);
+							@colliding = other;
+							break;
+						}
+					}
+				}
+			}
+			else {
+				if(!colliding.valid)
+					@colliding = null;
+				else {
+					vec3d off = obj.position - colliding.position;
+					double d = off.lengthSQ;
+					if(d <= (obj.radius + colliding.radius) * (obj.radius + colliding.radius)) {
+						off += random3d(0.1); off.normalize();
+						obj.position += off * min(time * colliding.radius * 0.5, d - colliding.radius + obj.radius);
+					}
+					else {
+						@colliding = null;
+					}
+				}
+			}
+		}
+
+		vec3d dest, destVel, destAccel;
+		PathNode@ pathNode;
+
+		{
+			double dot = targRot.dot(obj.rotation);
+			if(dot < 0.999) {
+				if(dot < -1.0)
+					dot = -1.0;
+				double angle = acos(dot);
+				double tickRot = rotSpeed * time;
+				if(angle > tickRot) {
+					obj.rotation = obj.rotation.slerp(targRot, tickRot / angle);
+				}
+				else {
+					obj.rotation = targRot;
+					rotating = false;
+				}
+			}
+			else {
+				if(dot != 1.0)
+					obj.rotation = targRot;
+				rotating = false;
+			}
+		}
+
+		Object@ leader = obj;
+		if(obj.hasSupportAI)
+			@leader = cast<Ship>(obj).Leader;
+
+		double doneRange = obj.radius;
+
+		if(FTL) {
+			vec3d prevPos = obj.position;
+			vec3d prevVel = obj.velocity;
+
+			vec3d movement = (destination - obj.position);
+			double speed = FTLSpeed * time;
+			double dist = movement.length;
+			if(dist <= speed) {
+				obj.position = destination;
+				obj.velocity = vec3d();
+				obj.acceleration = vec3d();
+				targRot = (!rotating && inCombat) ? combatFacing : targFacing;
+				FTL = false;
+
+				if(obj.hasLeaderAI)
+					playParticleSystem("FTLExit", obj.position, obj.rotation, obj.radius * 4.0, obj.visibleMask);
+			}
+			else {
+				movement.normalize(speed);
+
+				targRot = quaterniond_fromVecToVec(vec3d_front(), movement, vec3d_up());
+				obj.position += movement;
+				obj.velocity = movement / time;
+				obj.acceleration = vec3d();
+			}
+
+			return 0.1;
+		}
+		else if(leader is obj) {
+			if(!moving) {
+				if(lockTo is null) {
+					if(!rotating && inCombat)
+						targRot = combatFacing;
+					else
+						targRot = targFacing;
+					return 0.5;
+				}
+			}
+
+			//Check for path invalidation
+			if(prevPathId != 0 && prevPathId != obj.owner.PathId.value)
+				updatePath(obj);
+
+			//Get correct destination
+			uint pathLen = path is null ? 0 : path.length;
+			if(pathLen > 0) {
+				for(uint i = 0; i < pathLen; ++i) {
+					if(!path[i].valid(obj)) {
+						path.length = 0;
+						pathLen = 0;
+
+						vec3d destPos = destination;
+						if(target !is null)
+							destPos = (obj.position - target.position).normalize(targDist) + target.position;
+						obj.createPathTowards(destPos, target);
+					}
+				}
+
+				if(pathLen > 0) {
+					@pathNode = path[0];
+					if(pathNode.pathEntry !is null)
+						dest = pathNode.pathEntry.position;
+					else {
+						dest = pathNode.pathTo;
+						doneRange = max(pathNode.dist, doneRange);
+					}
+					//double space = pathNode.pathEntry.radius + obj.radius;
+					//dest += (obj.position - dest).normalize(space);
+				}
+			}
+			if(pathNode is null) {
+				if(lockTo !is null) {
+					dest = lockTo.position + lockOffset;
+					destVel = lockTo.velocity;
+					destAccel = lockTo.acceleration;
+
+					//Compensate for varying tick times
+					double tDiff = (obj.lastTick + time) - lockTo.lastTick;
+					if(tDiff != 0.0) {
+						dest += (destVel + (destAccel * (tDiff * 0.5))) * tDiff;
+						destVel += destAccel * tDiff;
+					}
+				}
+				else if(target !is null) {
+					if(target.valid) {
+						dest = target.position;
+						destVel = target.velocity;
+						destAccel = target.acceleration;
+
+						//Compensate for varying tick times
+						double tDiff = (obj.lastTick + time) - target.lastTick;
+						if(tDiff != 0.0) {
+							dest += (destVel + (destAccel * (tDiff * 0.5))) * tDiff;
+							destVel += destAccel * tDiff;
+						}
+
+						//Try to reach the target at a particular distance
+						//NOTE: This is inaccurate (the angle of the target will change during target prediction)
+						//		However, because we iterate over small time steps, the error should be relatively small
+						dest += (obj.position - dest).normalize(targDist);
+					}
+					else {
+						destination = target.position;
+						@target = null;
+					}
+				}
+				else {
+					dest = destination;
+				}
+			}
+		}
+		else {
+			quaterniond formationFacing;
+			Ship@ leaderShip = cast<Ship>(leader);
+			if(leaderShip !is null)
+				formationFacing = leaderShip.formationDest;
+
+			if(leader !is null) {
+				destVel = leader.velocity;
+				destAccel = leader.acceleration;
+				if(fleetRelative)
+					dest = leader.position + (formationFacing * cast<Ship>(obj).formationDest.xyz);
+				else
+					dest = leader.position + destination;
+
+				//Compensate for varying tick times
+				double tDiff = (obj.lastTick + time) - leader.lastTick;
+				if(tDiff != 0) {
+					dest += (destVel + (destAccel * (tDiff * 0.5))) * tDiff;
+					destVel += destAccel * tDiff;
+				}
+			}
+			else {
+				dest = obj.position;
+				destVel = vec3d();
+				destAccel = vec3d();
+			}
+		}
+
+		doneRange *= doneRange;
+		compDestination = dest;
+
+		double a = accel;
+
+		obj.position += obj.velocity * time;
+
+		if(obj.owner.ForbidDeepSpace != 0) {
+			Region@ reg = obj.region;
+			if(reg !is null && !obj.hasSupportAI) {
+				double dist = obj.position.distanceTo(reg.position+obj.velocity);
+				if(dist > reg.radius && dist <= reg.radius*1.05+obj.velocity.length) {
+					vec3d dir = obj.position - reg.position;
+					vec3d toPos = reg.position + dir.normalized(reg.radius * 0.999);
+					if(obj.hasLeaderAI) {
+						obj.teleportTo(toPos, movementPart=true);
+					}
+					else {
+						obj.position = toPos;
+						obj.velocity = vec3d();
+						obj.acceleration = vec3d();
+					}
+					stopMoving(obj, enterOrbit=false);
+				}
+			}
+		}
+
+		if(!isLocked && (a <= 0.0000001 || a != a)) {
+			double speed = obj.velocity.length;
+			double tickAccel = 0.1 * time;
+			if(speed < tickAccel) {
+				obj.velocity = vec3d();
+				if(moving) {
+					moverDelta = true;
+					moving = false;
+					if(obj.hasOrbit)
+						obj.remakeStandardOrbit();
+					prevPathId = 0;
+				}
+				return 0.25;
+			}
+			else {
+				if(moving && obj.hasOrbit) {
+					moverDelta = true;
+					moving = false;
+					if(obj.hasOrbit)
+						obj.remakeStandardOrbit();
+					prevPathId = 0;
+				}
+				obj.velocity *= (speed - tickAccel)/speed;
+				return 0.125;
+			}
+		}
+
+		//Check if we can decellerate to our target this tick
+		double tGoal = newtonArrivalTime(a, dest - obj.position, destVel - obj.velocity);
+		if(tGoal > 1.0e4 || tGoal != tGoal) {
+			//We might not be able to reach the target (infinite time), so make sure we're working with a vaguely sensible timeline
+			tGoal = 1.0e4;
+		}
+
+		if(pathNode !is null && (tGoal <= time || tGoal <= 1.0 || (obj.position + obj.velocity).distanceToSQ(dest) < doneRange)) {
+			if(pathNode.pathEntry !is null) {
+				playParticleSystem("GateFlash", obj.position, obj.rotation, obj.radius, obj.visibleMask, false);
+				if(obj.hasLeaderAI)
+					obj.teleportTo(pathNode.pathOut(), movementPart=true);
+				else {
+					obj.position = pathNode.pathOut();
+					obj.velocity = vec3d();
+					obj.acceleration = vec3d();
+				}
+				playParticleSystem("GateFlash", obj.position, obj.rotation, obj.radius, obj.visibleMask | pathNode.visionMask, false);
+			}
+			path.remove(pathNode);
+			posDelta = true;
+			moverDelta = true;
+			return 0.125;
+		}
+		else if(tGoal <= time || (lockTo !is null && isLocked)) {
+			obj.position = dest;
+			obj.velocity = destVel;
+			obj.acceleration = destAccel;
+
+			if(moving) {
+				moverDelta = true;
+				moving = false;
+				if(obj.hasOrbit)
+					obj.remakeStandardOrbit();
+				prevPathId = 0;
+			}
+
+			if(lockTo !is null)
+				isLocked = true;
+			if(rotating)
+				targRot = targFacing;
+			else if(inCombat)
+				targRot = combatFacing;
+			else if(leader !is obj && cast<Ship>(leader) !is null)
+				targRot = leader.rotation;
+			else
+				targRot = targFacing;
+			return 0.5;
+		}
+		else {
+			//Deal with flux
+			if(obj.owner.HasFlux != 0 && !obj.hasSupportAI) {
+				Region@ reg = obj.region;
+				if(reg !is null) {
+					if(dest.distanceToSQ(reg.position) > reg.radius*reg.radius) {
+						if(canFluxTo(obj, dest)) {
+							commitFlux(obj, dest);
+							return 0.25;
+						}
+						else if(obj.owner.ForbidDeepSpace != 0) {
+							double speed = obj.velocity.length;
+							if(speed < a)
+								obj.velocity = vec3d();
+							else
+								obj.velocity *= (speed - a)/speed;
+							obj.acceleration = vec3d();
+							return 0.25;
+						}
+					}
+				}
+			}
+
+			//Do movement
+			for(uint i = 0; i < 15; ++i) {
+				double tOff = tGoal - time;
+				vec3d predDest = dest + (destVel + (destAccel * (tOff * 0.5))) * tOff;
+				vec3d predVel = destVel + destAccel * tOff;
+
+				double requires = newtonArrivalTime(a, predDest - obj.position, predVel - obj.velocity);
+				//We may be near a case where we can't reach the target
+				if(requires > 1.0e4 || requires != requires)
+					break;
+
+				if(abs(requires - tGoal) < 0.02 || requires <= time) {
+					tGoal = requires;
+					break;
+				}
+				else {
+					double diff = abs(requires - tGoal) * 0.1;
+					vec3d primeDest = predDest + (predVel + (destAccel * (diff * 0.5))) * diff;
+					vec3d primeVel = predVel + destAccel * diff;
+
+					double then = timeToTarget(obj, a, primeDest, primeVel);
+
+					//Move to a guess for the next 0
+					double slope = ((then - requires) / diff) - 1.0;
+					double y = then - (requires + diff);
+					tGoal = (requires + diff) - y / slope;
+				}
+			}
+
+			vec3d prevPos = obj.position;
+			vec3d prevVel = obj.velocity;
+
+			if(tGoal > 1.0) {
+				if(leader !is obj && cast<Ship>(leader) !is null) {
+					if(obj.isDetached)
+						targRot = quaterniond_fromVecToVec(vec3d_front(), dest - obj.position, vec3d_up());
+					else
+						targRot = leader.rotation;
+				}
+				else if(inCombat)
+					targRot = combatFacing;
+				else
+					targRot = targFacing;
+			}
+
+			//Perform necessary acceleration at arbitrary accuracy
+			if(tGoal > time) {
+				//Flagships can only accelerate after they finish rotating
+				if((leader !is null && leader !is obj) || !rotating || vectorMovement) {
+					double timeLeft = time;
+					do {
+						double take = 0;
+						obj.acceleration = accToGoal(a, take, dest - obj.position, destVel - obj.velocity);
+						take = min(timeLeft, max(take, 0.01));
+						obj.position += obj.acceleration * (take * take * 0.5);
+						obj.velocity += obj.acceleration * take;
+						timeLeft -= take;
+					} while(timeLeft > 0.0001);
+
+					if(!vectorMovement) {
+						if((leader is obj || cast<Ship>(leader) is null) && obj.acceleration.lengthSQ > 0.01 && tGoal > 1.0)
+							targRot = quaterniond_fromVecToVec(vec3d_front(), dest - obj.position, vec3d_up());
+					}
+				}
+				else if(!vectorMovement) {
+					targRot = quaterniond_fromVecToVec(vec3d_front(), dest - obj.position, vec3d_up());
+				}
+			}
+			else {
+				obj.position = dest;
+				obj.velocity = destVel;
+				obj.acceleration = destAccel;
+			}
+
+			//double trueAcc = prevVel.distanceTo(obj.velocity) / time;
+			//if(trueAcc - a > 0.001)
+			//	error(trueAcc + " > " + a);
+
+			isLocked = false;
+			return tGoal * 0.5;
+		}
+	}
+
+	quaterniond get_targetRotation() {
+		return targRot;
+	}
+
+	void forceLockTo(Object@ obj) {
+		@lockTo = obj;
+		isLocked = true;
+	}
+
+	void checkOrbitObject(Object& obj, vec3d destPoint) {
+		Region@ reg = getRegion(destPoint);
+		if(reg is null)
+			return;
+
+		Object@ orbit = reg.getOrbitObject(destPoint);
+		if(orbit is null)
+			return;
+
+		@lockTo = orbit;
+		isLocked = false;
+		lockOffset = destPoint - orbit.position;
+
+		if(syncedID == moveID)
+			syncedID = -1;
+	}
+
+	PathNode@ dodge(Object& obj, const line3dd& line, Object@ ignore, Object@& prev) {
+		auto@ obstacle = trace(line, 0x1);
+		if(obstacle is null || obstacle is ignore || obstacle is prev || !(obstacle.isStar || obstacle.isPlanet))
+			return null;
+
+		double baseDist = line.start.distanceTo(obstacle.position);
+
+		@prev = obstacle;
+
+		double dist = (obj.radius + obstacle.radius) * 2.0;
+		dist = max(dist, sqrt(baseDist));
+
+		vec3d pt = line.getClosestPoint(obstacle.position, false);
+		if(pt != obstacle.position)
+			pt = obstacle.position + (pt - obstacle.position).normalized(dist);
+		else
+			pt = obstacle.position + quaterniond_fromAxisAngle(line.direction, randomd(-pi,pi)) * line.direction.cross(vec3d_up()).normalized(dist);
+
+		PathNode node;
+		node.pathTo = pt;
+		node.dist = (dist + (pt - line.start).normalize().dot(pt - obstacle.position)); //The less perpendicular the course, the further away we can start changing course
+		node.dist = min(node.dist, line.start.distanceTo(pt) * 0.5);
+		return node;
+	}
+
+	void createPathTowards(Object& obj, vec3d point, Object@ targ = null) {
+		auto@ temp = path;
+		if(temp is null)
+			@temp = array<PathNode@>();
+		@path = null;
+		pathOddityGates(obj.owner, temp, obj.position, point, maxAcceleration);
+
+		if(maxAcceleration > 0) {
+			Object@ prev;
+			vec3d from = obj.position + obj.velocity * (obj.velocity.length / (maxAcceleration * 2.0));
+			for(uint i = 0; i < temp.length && temp.length < 50; ++i) {
+				if(i > 0) {
+					auto@ f = temp[i-1];
+					if(f.pathExit !is null)
+						from = f.pathExit.position;
+					else
+						from = f.pathTo;
+				}
+				vec3d to;
+				auto@ node = temp[i];
+				if(node.pathEntry !is null)
+					to = node.pathEntry.position;
+				else
+					to = node.pathTo;
+				line3dd line(from, to);
+				@node = dodge(obj, line, targ, prev);
+				if(node !is null)
+					temp.insertAt(i, @node);
+			}
+
+			if(temp.length > 0) {
+				auto@ f = temp.last;
+				if(f.pathExit !is null)
+					from = f.pathExit.position;
+				else
+					from = f.pathTo;
+			}
+
+			while(temp.length < 50) {
+				line3dd line(from, point);
+				auto@ node = dodge(obj, line, targ, prev);
+				if(node is null)
+					break;
+				temp.insertLast(@node);
+				from = node.pathTo;
+			}
+		}
+
+		if(temp.length > 0)
+			@path = temp;
+		prevPathId = obj.owner.PathId.value;
+		moverDelta = true;
+	}
+
+	void updatePath(Object& obj) {
+		prevPathId = obj.owner.PathId.value;
+		vec3d dest = destination;
+		if(target !is null)
+			dest = (obj.position - target.position).normalize(targDist) + target.position;
+
+		array<PathNode@> newPath;
+		pathOddityGates(obj.owner, newPath, obj.position, dest, maxAcceleration);
+
+		double prevETA = getPathETA(obj.position, dest, maxAcceleration, path);
+		double newETA = getPathETA(obj.position, dest, maxAcceleration, newPath);
+
+		double vel = obj.velocity.length;
+		double t = (vel / maxAcceleration);
+		newETA += t + sqrt(t * vel * 0.5 / maxAcceleration);
+
+		if(newETA < prevETA) {
+			@path = newPath;
+			moverDelta = true;
+		}
+	}
+
+	bool isOnMoveOrder(int id) {
+		return !FTL && id == moveID && moving;
+	}
+
+	bool moveTo(Object& obj, vec3d point, int& id, bool doPathing = true, bool enterOrbit = true, bool allowStop = false) {
+		if(FTL)
+			return false;
+		if(id > 0 && id == moveID)
+			return !moving;
+
+		moving = true;
+		destination = point;
+		@target = null;
+		@lockTo = null;
+
+		if(obj.hasOrbit && obj.inOrbit)
+			obj.stopOrbit();
+
+		if(!vectorMovement || !inCombat) {
+			if(allowStop) {
+				double d = point.distanceToSQ(obj.position);
+				if(d > sqr(obj.radius + obj.velocity.length))
+					allowStop = false;
+			}
+			if(!allowStop) {
+				rotating = true;
+				targRot = quaterniond_fromVecToVec(vec3d_front(), point - obj.position, vec3d_up());
+			}
+		}
+
+		id = ++moveID;
+
+		if(doPathing) {
+			if(path !is null)
+				path.length = 0;
+			obj.createPathTowards(point);
+			if(enterOrbit && !obj.isPlanet)
+				obj.checkOrbitObject(destination);
+		}
+		else {
+			@path = null;
+			prevPathId = 0;
+		}
+
+		return false;
+	}
+
+	bool moveTo(Object& obj, Object& targ, int& id, double distance = 0.0, bool doPathing = true, bool enterOrbit = true) {
+		if(FTL)
+			return false;
+		if(id > 0 && id == moveID)
+			return !moving;
+
+		moving = true;
+		@target = targ;
+		@lockTo = null;
+
+		if(obj.hasOrbit && obj.inOrbit)
+			obj.stopOrbit();
+
+		if(targ.isRegion)
+			targDist = targ.radius * 0.85;
+		else
+			targDist = max(distance, obj.radius + targ.radius);
+
+		if(!vectorMovement || !inCombat) {
+			rotating = true;
+			targRot = quaterniond_fromVecToVec(vec3d_front(), targ.position - obj.position, vec3d_up());
+		}
+
+		id = ++moveID;
+
+		if(doPathing) {
+			if(path !is null)
+				path.length = 0;
+			vec3d destPos = (obj.position - targ.position).normalize(targDist) + targ.position;
+			obj.createPathTowards(destPos, targ);
+			if(enterOrbit && !obj.isPlanet)
+				obj.checkOrbitObject(destPos);
+		}
+		else {
+			@path = null;
+			prevPathId = 0;
+		}
+
+		return false;
+	}
+
+	void stopMoving(Object& obj, bool doPathing = false, bool enterOrbit = true) {
+		int dummy = -1;
+		if(accel > 1.0e-4)
+			moveTo(obj, obj.position + obj.velocity * min(abs(obj.velocity.length) * 0.5 / accel, 30.0), dummy, doPathing, enterOrbit, allowStop=true);
+		else
+			moveTo(obj, obj.position, dummy, doPathing, enterOrbit, allowStop=true);
+	}
+
+	void clearMovement(Object& obj) {
+		if(!moving)
+			return;
+		moving = false;
+		moverDelta = true;
+		rotating = false;
+		if(obj.hasOrbit)
+			obj.remakeStandardOrbit();
+	}
+
+	bool rotateTo(Object& obj, quaterniond rotation, int& id) {
+		if(obj.hasOrbit && obj.inOrbit)
+			return true;
+		id = moveID;
+		rotation.normalize();
+		if(targFacing != rotation) {
+			facingDelta = true;
+			targFacing = rotation;
+		}
+
+		if(obj.rotation.dot(targFacing) > 0.999) {
+			return true;
+		}
+		else {
+			targRot = rotation;
+			rotating = true;
+			return false;
+		}
+	}
+
+	void setRotation(Object& obj, quaterniond rotation) {
+		rotation.normalize();
+		if(targFacing != rotation) {
+			targFacing = rotation;
+			facingDelta = true;
+		}
+	}
+
+	void setCombatFacing(Object& obj, quaterniond& rotation) {
+		quaterniond prev = combatFacing;
+		bool prevCombat = inCombat;
+
+		combatFacing = rotation;
+		combatFacing.normalize();
+		inCombat = true;
+
+		if(prev != combatFacing || !prevCombat)
+			facingDelta = true;
+	}
+
+	void clearCombatFacing(Object& obj) {
+		if(inCombat) {
+			inCombat = false;
+			facingDelta = true;
+		}
+	}
+
+	void flagPositionUpdate(Object& obj) {
+		moverDelta = true;
+		posDelta = true;
+		obj.wake();
+	}
+
+	bool writeMoverDelta(const Object& obj, Message& msg) {
+		const Ship@ ship = cast<const Ship@>(obj);
+		if(syncedID != moveID || moverDelta) {
+			msg.write1();
+			msg.write1();
+			writeMover(obj, msg);
+
+			if(obj.velocity.lengthSQ < 0.001 || posDelta) {
+				msg.write1();
+				msg.writeMedVec3(obj.position);
+				posDelta = false;
+			}
+			else {
+				msg.write0();
+			}
+
+			syncedID = moveID;
+			moverDelta = false;
+			facingDelta = false;
+			return true;
+		}
+		else if(facingDelta) {
+			msg.write1();
+			msg.write0();
+			msg.write1();
+			msg.writeBit(inCombat);
+			if(inCombat)
+				msg.writeRotation(combatFacing);
+			else {
+				msg.writeBit(rotating);
+				if(rotating)
+					msg.writeRotation(targFacing);
+			}
+			facingDelta = false;
+			return true;
+		}
+		else if(ship !is null && prevFormationDest != ship.formationDest) {
+			msg.write1();
+			msg.write0();
+			msg.write0();
+			if(ship.hasLeaderAI)
+				msg.writeRotation(ship.formationDest);
+			else
+				msg.writeSmallVec3(ship.formationDest.xyz);
+			prevFormationDest = ship.formationDest;
+			return true;
+		}
+		return false;
+	}
+
+	void readMoverDelta(Object& obj, Message& msg) {
+		if(msg.readBit()) {
+			readMover(obj, msg);
+
+			if(msg.readBit()) {
+				obj.position = msg.readMedVec3();
+				obj.velocity = vec3d();
+				obj.acceleration = vec3d();
+			}
+		}
+		else {
+			if(msg.readBit()) {
+				inCombat = msg.readBit();
+				if(inCombat)
+					combatFacing = msg.readRotation();
+				else if(msg.readBit()) {
+					rotating = true;
+					targFacing = msg.readRotation();
+				}
+			}
+			else {
+				Ship@ ship = cast<Ship>(obj);
+				if(ship.hasLeaderAI)
+					ship.formationDest = msg.readRotation();
+				else
+					ship.formationDest.xyz = msg.readSmallVec3();
+			}
+		}
+	}
+
+	void writeMover(const Object& obj, Message& msg) {
+		msg << float(accel);
+		if(rotSpeed == shipRotSpeed) {
+			msg.write0();
+		}
+		else {
+			msg.write1();
+			msg << float(rotSpeed);
+		}
+		msg.writeBit(vectorMovement);
+
+		if(targRot == targFacing) {
+			msg.write1();
+			msg.writeRotation(targRot);
+		}
+		else {
+			msg.write0();
+			msg.writeRotation(targRot);
+			msg.writeRotation(targFacing);
+		}
+
+		msg << moving;
+		msg << rotating;
+		msg << FTL;
+		if(FTL)
+			msg << float(FTLSpeed);
+		msg << inCombat;
+		if(inCombat)
+			msg.writeRotation(combatFacing);
+		if(obj.hasSupportAI)
+			msg << fleetRelative;
+
+		uint pathCnt = path is null ? 0 : path.length;
+		msg.writeBit(pathCnt != 0);
+		if(pathCnt != 0) {
+			msg.writeSmall(pathCnt);
+			for(uint i = 0; i < pathCnt; ++i)
+				msg << path[i];
+		}
+
+		if(lockTo !is null) {
+			msg.write1();
+			msg << lockTo;
+			msg << isLocked;
+			msg.writeSmallVec3(lockOffset);
+		}
+		else {
+			msg.write0();
+		}
+
+		const Ship@ ship = cast<const Ship@>(obj);
+		if(ship !is null) {
+			msg.write1();
+			if(ship.hasLeaderAI)
+				msg.writeRotation(ship.formationDest);
+			else if(fleetRelative)
+				msg.writeSmallVec3(ship.formationDest.xyz);
+		}
+		else {
+			msg.write0();
+		}
+
+		if(target !is null) {
+			msg.write1();
+			msg << target;
+			msg << float(targDist);
+		}
+		else {
+			msg.write0();
+			if(!FTL && obj.hasSupportAI) {
+				if(!fleetRelative)
+					msg.writeSmallVec3(destination);
+			}
+			else {
+				msg.writeMedVec3(destination);
+			}
+		}
+	}
+
+	void readMover(Object& obj, Message& msg) {
+		accel = msg.read_float();
+		if(msg.readBit())
+			rotSpeed = msg.read_float();
+		else
+			rotSpeed = shipRotSpeed;
+		vectorMovement = msg.readBit();
+
+		if(msg.readBit()) {
+			targFacing = msg.readRotation();
+			targRot = targFacing;
+		}
+		else {
+			targRot = msg.readRotation();
+			targFacing = msg.readRotation();
+		}
+
+		msg >> moving;
+		msg >> rotating;
+		++moveID;
+		bool prevFTL = FTL;
+		msg >> FTL;
+		if(FTL)
+			FTLSpeed = msg.read_float();
+
+		msg >> inCombat;
+		if(inCombat)
+			combatFacing = msg.readRotation();
+		if(obj.hasSupportAI)
+			msg >> fleetRelative;
+
+		uint pathCnt = 0;
+		if(msg.readBit())
+			pathCnt = msg.readSmall();
+		if(pathCnt == 0)
+			@path = null;
+		else {
+			if(path is null)
+				@path = array<PathNode@>();
+			path.length = pathCnt;
+			for(uint i = 0; i < pathCnt; ++i) {
+				if(path[i] is null)
+					@path[i] = PathNode();
+				msg >> path[i];
+			}
+		}
+
+		if(prevFTL && !FTL)
+			obj.velocity = vec3d();
+
+		if(msg.readBit()) {
+			msg >> lockTo;
+			msg >> isLocked;
+			lockOffset = msg.readSmallVec3();
+		}
+		else {
+			@lockTo = null;
+		}
+
+		if(msg.readBit()) {
+			Ship@ ship = cast<Ship>(obj);
+			if(ship.hasLeaderAI)
+				ship.formationDest = msg.readRotation();
+			else if(fleetRelative)
+				ship.formationDest.xyz = msg.readSmallVec3();
+		}
+
+		if(msg.readBit()) {
+			msg >> target;
+			float td = 0;
+			msg >> td;
+			targDist = td;
+		}
+		else {
+			if(!FTL && obj.hasSupportAI) {
+				if(!fleetRelative)
+					destination = msg.readSmallVec3();
+			}
+			else {
+				destination = msg.readMedVec3();
+			}
+			@target = null;
+		}
+	}
+};

--- a/OpenSR/scripts/server/components/Statuses.as
+++ b/OpenSR/scripts/server/components/Statuses.as
@@ -73,6 +73,33 @@ tidy class Statuses : Component_Statuses, Savable {
 		return statuses[index].stacks;
 	}
 
+	// CE: Port status duration
+	double get_statusEffectDuration(uint index) {
+		if(index >= statuses.length)
+			return 0.0;
+		uint statusTypeID = statuses[index].type.id;
+		if (!statuses[index].type.showDuration) {
+			return -2.0;
+		}
+		// We can have multiple stacks of instances of the same status (type)
+		// but all instances tick down at the same time, so we just need
+		// to find the longest lasting instance (-1 is permanent)
+		double duration = 0.0;
+		for(uint i = 0, cnt = instances.length; i < cnt; ++i) {
+			StatusInstance@ instance = instances[i];
+			if (instance.status.type.id == statusTypeID) {
+				if (instance.timer == -1.0) {
+					duration = -1.0;
+					continue;
+				}
+				if (duration != -1.0 && instance.timer > duration) {
+					duration = instance.timer;
+				}
+			}
+		}
+		return duration;
+	}
+
 	Object@ get_statusEffectOriginObject(uint index) {
 		if(index >= statuses.length)
 			return null;
@@ -125,6 +152,14 @@ tidy class Statuses : Component_Statuses, Savable {
 				return true;
 		}
 		return false;
+	}
+
+	int getStatusEffectOfType(uint typeId) {
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				return i;
+		}
+		return -1;
 	}
 
 	int addStatus(Object& obj, double timer, uint typeId, Empire@ boundEmpire = null, Region@ boundRegion = null, Empire@ originEmpire = null, Object@ originObject = null) {
@@ -340,6 +375,30 @@ tidy class Statuses : Component_Statuses, Savable {
 		msg.writeSmall(cnt);
 		for(uint i = 0; i < cnt; ++i)
 			msg << statuses[i];
+		// CE: port status duration
+		// We'd have deltas literally every frame if we tried to sync the
+		// current timer on each instance because it updates in real time, so
+		// instead we sync the time as of the netcode sync and the timer, and
+		// approximate the present time timer on the client each frame.
+		// Since the server still uses the real timer, any rounding disrepances
+		// will fix themselves when something makes us write the statuses again.
+		msg << gameTime;
+		cnt = instances.length;
+		msg.writeSmall(cnt);
+		for (uint i = 0; i < cnt; ++i) {
+			StatusInstance@ instance = instances[i];
+			// The client only needs to care about a timers in a few
+			// statuses when they're not infinite, so don't waste network
+			// bandwidth writing the timer or the status type if the instance
+			// isn't on a timer or it's not a type we need to display in the client
+			if (instance.timer == -1.0 || !instance.status.type.showDuration) {
+				msg.write0();
+			} else {
+				msg.write1();
+				msg << float(instance.timer);
+				msg << instance.status.type.id;
+			}
+		}
 	}
 
 	bool writeStatusDelta(Message& msg) {

--- a/OpenSR/scripts/server/components/Statuses.as
+++ b/OpenSR/scripts/server/components/Statuses.as
@@ -1,0 +1,354 @@
+import statuses;
+import saving;
+
+tidy class Statuses : Component_Statuses, Savable {
+	array<Status@> statuses;
+	array<StatusInstance@> instances;
+	int nextInstanceId = 1;
+	bool delta = false;
+
+	void save(SaveFile& file) {
+		file << nextInstanceId;
+
+		uint cnt = statuses.length;
+		file << cnt;
+		for(uint i = 0; i < cnt; ++i)
+			file << statuses[i];
+
+		cnt = instances.length;
+		file << cnt;
+		for(uint i = 0; i < cnt; ++i) {
+			file << statuses.find(instances[i].status);
+			file << instances[i];
+		}
+	}
+
+	void load(SaveFile& file) {
+		if(file < SV_0013)
+			return;
+
+		file >> nextInstanceId;
+
+		uint cnt = 0;
+		file >> cnt;
+		statuses.length = cnt;
+		for(uint i = 0; i < cnt; ++i) {
+			@statuses[i] = Status();
+			file >> statuses[i];
+		}
+
+		file >> cnt;
+		instances.length = cnt;
+		for(uint i = 0; i < cnt; ++i) {
+			@instances[i] = StatusInstance();
+			int index = 0;
+			file >> index;
+			@instances[i].status = statuses[index];
+			file >> instances[i];
+		}
+	}
+
+	void getStatusEffects(Player& pl, Object& obj) {
+		Empire@ plEmp = pl.emp;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(!statuses[i].isVisibleTo(obj, plEmp))
+				continue;
+			yield(statuses[i]);
+		}
+	}
+
+	uint get_statusEffectCount() {
+		return statuses.length;
+	}
+
+	uint get_statusEffectType(uint index) {
+		if(index >= statuses.length)
+			return uint(-1);
+		return statuses[index].type.id;
+	}
+
+	uint get_statusEffectStacks(uint index) {
+		if(index >= statuses.length)
+			return 0;
+		return statuses[index].stacks;
+	}
+
+	Object@ get_statusEffectOriginObject(uint index) {
+		if(index >= statuses.length)
+			return null;
+		return statuses[index].originObject;
+	}
+
+	Empire@ get_statusEffectOriginEmpire(uint index) {
+		if(index >= statuses.length)
+			return null;
+		return statuses[index].originEmpire;
+	}
+
+	uint getStatusStackCountAny(uint typeId) {
+		uint count = 0;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				count += statuses[i].stacks;
+		}
+		return count;
+	}
+
+	uint getStatusStackCount(uint typeId, Object@ originObject = null, Empire@ originEmpire = null) {
+		uint count = 0;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId && statuses[i].originObject is originObject && statuses[i].originEmpire is originEmpire)
+				count += statuses[i].stacks;
+		}
+		return count;
+	}
+
+	uint get_statusInstanceCount() {
+		return instances.length;
+	}
+
+	uint get_statusInstanceType(uint index) {
+		if(index >= instances.length)
+			return uint(-1);
+		return instances[index].status.type.id;
+	}
+
+	int get_statusInstanceId(uint index) {
+		if(index >= instances.length)
+			return -1;
+		return instances[index].id;
+	}
+
+	bool hasStatusEffect(uint typeId) {
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				return true;
+		}
+		return false;
+	}
+
+	int addStatus(Object& obj, double timer, uint typeId, Empire@ boundEmpire = null, Region@ boundRegion = null, Empire@ originEmpire = null, Object@ originObject = null) {
+		const StatusType@ type = getStatusType(typeId);
+		if(type is null)
+			return -1;
+
+		Status@ status;
+		if(type.collapses) {
+			for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+				auto@ cur = statuses[i];
+				if(cur.type is type && originEmpire is cur.originEmpire && originObject is cur.originObject) {
+					@status = cur;
+					break;
+				}
+			}
+		}
+		if(status is null) {
+			@status = Status(type);
+			@status.originEmpire = originEmpire;
+			@status.originObject = originObject;
+			status.create(obj);
+			statuses.insertLast(status);
+		}
+
+		auto@ instance = status.instance(obj);
+		instance.id = nextInstanceId++;
+		instance.timer = timer;
+		@instance.boundEmpire = boundEmpire;
+		@instance.boundRegion = boundRegion;
+		instances.insertLast(instance);
+		delta = true;
+		return instance.id;
+	}
+
+	void addStatus(Object& obj, uint typeId, double timer = -1.0, Empire@ boundEmpire = null, Region@ boundRegion = null, Empire@ originEmpire = null, Object@ originObject = null) {
+		addStatus(obj, timer, typeId, boundEmpire, boundRegion, originEmpire, originObject);
+	}
+
+	void addRandomCondition(Object& obj) {
+		if(!obj.isPlanet)
+			return;
+		auto@ type = getRandomCondition(cast<Planet>(obj));
+		if(type !is null)
+			addStatus(obj, type.id);
+	}
+
+	void removeStatus(Object& obj, int id) {
+		StatusInstance@ instance;
+		for(uint i = 0, cnt = instances.length; i < cnt; ++i) {
+			if(instances[i].id == id) {
+				@instance = instances[i];
+				instances.removeAt(i);
+				break;
+			}
+		}
+		if(instance is null)
+			return;
+		instance.remove(obj);
+		if(instance.status.stacks <= 0) {
+			statuses.remove(instance.status);
+			instance.status.destroy(obj);
+		}
+		delta = true;
+	}
+
+	bool isStatusInstanceActive(int id) {
+		for(uint i = 0, cnt = instances.length; i < cnt; ++i) {
+			if(instances[i].id == id)
+				return true;
+		}
+		return false;
+	}
+
+	void removeStatusInstanceOfType(Object& obj, uint typeId) {
+		StatusInstance@ instance;
+		for(uint i = 0, cnt = instances.length; i < cnt; ++i) {
+			auto@ inst = instances[i];
+			if(inst.boundEmpire !is null)
+				continue;
+			if(inst.boundRegion !is null)
+				continue;
+			if(inst.timer >= 0)
+				continue;
+			if(inst.status.type.id == typeId) {
+				@instance = inst;
+				instances.removeAt(i);
+				break;
+			}
+		}
+		if(instance is null)
+			return;
+		instance.remove(obj);
+		if(instance.status.stacks <= 0) {
+			statuses.remove(instance.status);
+			instance.status.destroy(obj);
+		}
+		delta = true;
+	}
+
+	void removeStatusType(Object& obj, uint typeId) {
+		uint index = uint(-1);
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			auto@ cur = statuses[i];
+			if(cur.type.id == typeId) {
+				index = i;
+				break;
+			}
+		}
+		if(index == uint(-1))
+			return;
+		removeStatusTypeByIndex(obj, index);
+	}
+
+	void removeStatusTypeByIndex(Object& obj, uint index) {
+		Status@ status;
+		if(index < statuses.length)
+			@status = statuses[index];
+		if(status is null)
+			return;
+		for(int j = instances.length - 1; j >= 0; --j) {
+			if(instances[j].status is status) {
+				status.remove(obj, instances[j]);
+				instances.removeAt(j);
+			}
+		}
+		statuses.removeAt(index);
+		status.destroy(obj);
+		delta = true;
+	}
+
+	void changeStatusOwner(Object& obj, Empire@ prevOwner, Empire@ newOwner) {
+		for(int i = instances.length - 1; i >= 0; --i) {
+			auto@ instance = instances[i];
+			if(instance.boundEmpire !is null && instance.boundEmpire is prevOwner) {
+				instance.remove(obj);
+				instances.removeAt(i);
+			}
+		}
+		for(int i = statuses.length - 1; i >= 0; --i) {
+			auto@ status = statuses[i];
+			if(status.stacks <= 0 || !status.ownerChange(obj, prevOwner, newOwner))
+				removeStatusTypeByIndex(obj, i);
+		}
+	}
+
+	void changeStatusRegion(Object& obj, Region@ prevRegion, Region@ newRegion) {
+		for(int i = instances.length - 1; i >= 0; --i) {
+			auto@ instance = instances[i];
+			if(instance.boundRegion !is null && instance.boundRegion is prevRegion) {
+				instance.remove(obj);
+				instances.removeAt(i);
+			}
+		}
+		for(int i = statuses.length - 1; i >= 0; --i) {
+			auto@ status = statuses[i];
+			if(status.stacks <= 0 || !status.regionChange(obj, prevRegion, newRegion))
+				removeStatusTypeByIndex(obj, i);
+		}
+	}
+
+	void removeRegionBoundStatus(Object& obj, Region@ region, uint typeId, double timer = -1.0) {
+		for(int i = instances.length - 1; i >= 0; --i) {
+			auto@ instance = instances[i];
+			if(instance.boundRegion is region && instance.status.type.id == typeId
+				&& abs(instance.timer - timer) < 0.9) {
+				instances.removeAt(i);
+				instance.remove(obj);
+
+				for(int j = statuses.length - 1; j >= 0; --j) {
+					auto@ status = statuses[j];
+					if(status.stacks <= 0)
+						removeStatusTypeByIndex(obj, j);
+				}
+				break;
+			}
+		}
+	}
+
+	void statusTick(Object& obj, double time) {
+		for(int i = instances.length - 1; i >= 0; --i) {
+			auto@ instance = instances[i];
+			if(!instance.tick(obj, time))
+				instances.removeAt(i);
+		}
+		for(int i = statuses.length - 1; i >= 0; --i) {
+			auto@ status = statuses[i];
+			if(status.stacks <= 0 || !status.tick(obj, time))
+				removeStatusTypeByIndex(obj, i);
+		}
+	}
+
+	void destroyStatus(Object& obj) {
+		for(int i = statuses.length - 1; i >= 0; --i) {
+			auto@ status = statuses[i];
+			status.objectDestroy(obj);
+		}
+		for(uint i = 0; i < instances.length; ++i) {
+			auto@ instance = instances[i];
+			instance.remove(obj);
+			if(instance.status.stacks <= 0) {
+				statuses.remove(instance.status);
+				instance.status.destroy(obj);
+			}
+		}
+
+		statuses.length = 0;
+		instances.length = 0;
+	}
+
+	void writeStatuses(Message& msg) const {
+		uint cnt = statuses.length;
+		msg.writeSmall(cnt);
+		for(uint i = 0; i < cnt; ++i)
+			msg << statuses[i];
+	}
+
+	bool writeStatusDelta(Message& msg) {
+		if(delta) {
+			delta = false;
+			msg.write1();
+			writeStatuses(msg);
+			return true;
+		}
+		return false;
+	}
+};

--- a/OpenSR/scripts/shadow/components/Statuses.as
+++ b/OpenSR/scripts/shadow/components/Statuses.as
@@ -1,0 +1,82 @@
+import statuses;
+
+tidy class Statuses : Component_Statuses {
+	array<Status@> statuses;
+
+	void getStatusEffects(Player& pl, Object& obj) {
+		Empire@ plEmp = pl.emp;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(!statuses[i].isVisibleTo(obj, plEmp))
+				continue;
+			yield(statuses[i]);
+		}
+	}
+
+	uint get_statusEffectCount() {
+		return statuses.length;
+	}
+
+	uint get_statusEffectType(uint index) {
+		if(index >= statuses.length)
+			return uint(-1);
+		return statuses[index].type.id;
+	}
+
+	uint get_statusEffectStacks(uint index) {
+		if(index >= statuses.length)
+			return 0;
+		return statuses[index].stacks;
+	}
+
+	Object@ get_statusEffectOriginObject(uint index) {
+		if(index >= statuses.length)
+			return null;
+		return statuses[index].originObject;
+	}
+
+	Empire@ get_statusEffectOriginEmpire(uint index) {
+		if(index >= statuses.length)
+			return null;
+		return statuses[index].originEmpire;
+	}
+
+	uint getStatusStackCountAny(uint typeId) {
+		uint count = 0;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				count += statuses[i].stacks;
+		}
+		return count;
+	}
+
+	uint getStatusStackCount(uint typeId, Object@ originObject = null, Empire@ originEmpire = null) {
+		uint count = 0;
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId && statuses[i].originObject is originObject && statuses[i].originEmpire is originEmpire)
+				count += statuses[i].stacks;
+		}
+		return count;
+	}
+
+	bool hasStatusEffect(uint typeId) {
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				return true;
+		}
+		return false;
+	}
+
+	void readStatuses(Message& msg) {
+		uint cnt = msg.readSmall();
+		statuses.length = cnt;
+		for(uint i = 0; i < cnt; ++i) {
+			if(statuses[i] is null)
+				@statuses[i] = Status();
+			msg >> statuses[i];
+		}
+	}
+
+	void readStatusDelta(Message& msg) {
+		readStatuses(msg);
+	}
+};

--- a/OpenSR/scripts/shadow/components/Statuses.as
+++ b/OpenSR/scripts/shadow/components/Statuses.as
@@ -1,7 +1,14 @@
 import statuses;
 
+class StatusInstanceShadow {
+	double timer = -1.0;
+	uint statusTypeID = uint(-1);
+}
+
 tidy class Statuses : Component_Statuses {
 	array<Status@> statuses;
+	array<StatusInstanceShadow@> instances;
+	double networkSyncTime = gameTime;
 
 	void getStatusEffects(Player& pl, Object& obj) {
 		Empire@ plEmp = pl.emp;
@@ -26,6 +33,37 @@ tidy class Statuses : Component_Statuses {
 		if(index >= statuses.length)
 			return 0;
 		return statuses[index].stacks;
+	}
+
+	double get_statusEffectDuration(uint index) {
+		if(index >= statuses.length)
+			return 0.0;
+		uint statusTypeID = statuses[index].type.id;
+		if (!statuses[index].type.showDuration) {
+			return -2.0;
+		}
+		// We can have multiple stacks of instances of the same status (type)
+		// but all instances tick down at the same time, so we just need
+		// to find the longest lasting instance (-1 is permanent)
+		double duration = 0.0;
+		for(uint i = 0, cnt = instances.length; i < cnt; ++i) {
+			StatusInstanceShadow@ instance = instances[i];
+			if (instance.statusTypeID == statusTypeID) {
+				if (instance.timer == -1.0) {
+					duration = -1.0;
+					continue;
+				}
+				if (duration != -1.0 && instance.timer > duration) {
+					duration = instance.timer;
+				}
+			}
+		}
+		if (duration == -1.0) {
+			return -1.0;
+		} else {
+			double elapsedTime = gameTime - networkSyncTime;
+			return max(duration - elapsedTime, 0.0);
+		}
 	}
 
 	Object@ get_statusEffectOriginObject(uint index) {
@@ -66,6 +104,14 @@ tidy class Statuses : Component_Statuses {
 		return false;
 	}
 
+	int getStatusEffectOfType(uint typeId) {
+		for(uint i = 0, cnt = statuses.length; i < cnt; ++i) {
+			if(statuses[i].type.id == typeId)
+				return i;
+		}
+		return -1;
+	}
+
 	void readStatuses(Message& msg) {
 		uint cnt = msg.readSmall();
 		statuses.length = cnt;
@@ -73,6 +119,19 @@ tidy class Statuses : Component_Statuses {
 			if(statuses[i] is null)
 				@statuses[i] = Status();
 			msg >> statuses[i];
+		}
+		msg >> networkSyncTime;
+		cnt = msg.readSmall();
+		instances.length = cnt;
+		for (uint i = 0; i < cnt; ++i) {
+			if (msg.readBit()) {
+				StatusInstanceShadow@ instance = StatusInstanceShadow();
+				instance.timer = msg.read_float();
+				msg >> instance.statusTypeID;
+				@instances[i] = instance;
+			} else {
+				@instances[i] = StatusInstanceShadow();
+			}
 		}
 	}
 

--- a/OpenSR/scripts/toolkit/elements/GuiStatusBox.as
+++ b/OpenSR/scripts/toolkit/elements/GuiStatusBox.as
@@ -2,6 +2,7 @@
 import elements.BaseGuiElement;
 import elements.MarkupTooltip;
 import statuses;
+import util.formatting;
 
 export GuiStatusBox;
 export updateStatusBoxes;
@@ -9,15 +10,16 @@ export updateStatusBoxes;
 class GuiStatusBox : BaseGuiElement {
 	Status status;
 	Object@ fromObject;
+	MarkupTooltip@ lazyTooltip;
 
 	GuiStatusBox(IGuiElement@ parent) {
 		super(parent, recti());
-		addLazyMarkupTooltip(this, width=350);
+		@lazyTooltip = addLazyMarkupTooltip(this, width=350);
 	}
 
 	GuiStatusBox(IGuiElement@ parent, const recti& pos) {
 		super(parent, pos);
-		addLazyMarkupTooltip(this, width=350);
+		@lazyTooltip = addLazyMarkupTooltip(this, width=350);
 		updateAbsolutePosition();
 	}
 
@@ -26,6 +28,22 @@ class GuiStatusBox : BaseGuiElement {
 	}
 
 	string get_tooltip() {
+		if (status.type.showDuration) {
+			int index = fromObject.getStatusEffectOfType(status.type.id);
+			if (index != -1) {
+				double duration = fromObject.get_statusEffectDuration(index);
+				if (duration > 0) {
+					lazyTooltip.LazyUpdate = true;
+					return status.getTooltip(valueObject=fromObject) +
+						"\n" + locale::DURATION + ": " +
+						format(locale::TIME_S, toString(duration, 0));
+				}
+			}
+			lazyTooltip.LazyUpdate = false;
+			return status.getTooltip(valueObject=fromObject);
+		} else {
+			lazyTooltip.LazyUpdate = false;
+		}
 		return status.getTooltip(valueObject=fromObject);
 	}
 

--- a/OpenSR/scripts/toolkit/elements/GuiStatusBox.as
+++ b/OpenSR/scripts/toolkit/elements/GuiStatusBox.as
@@ -1,0 +1,64 @@
+#section game
+import elements.BaseGuiElement;
+import elements.MarkupTooltip;
+import statuses;
+
+export GuiStatusBox;
+export updateStatusBoxes;
+
+class GuiStatusBox : BaseGuiElement {
+	Status status;
+	Object@ fromObject;
+
+	GuiStatusBox(IGuiElement@ parent) {
+		super(parent, recti());
+		addLazyMarkupTooltip(this, width=350);
+	}
+
+	GuiStatusBox(IGuiElement@ parent, const recti& pos) {
+		super(parent, pos);
+		addLazyMarkupTooltip(this, width=350);
+		updateAbsolutePosition();
+	}
+
+	void update(const Status& other) {
+		status = other;
+	}
+
+	string get_tooltip() {
+		return status.getTooltip(valueObject=fromObject);
+	}
+
+	void draw() {
+		(spritesheet::ResourceIconsSmallMods+0).draw(AbsolutePosition, status.type.color);
+		status.type.icon.draw(AbsolutePosition.padded(2));
+
+		if(!status.type.unique && status.stacks > 1) {
+			skin.getFont(FT_Bold).draw(
+				pos=AbsolutePosition.padded(0,0,0,5),
+				horizAlign=1.0,
+				vertAlign=1.0,
+				text=format("x$1", toString(status.stacks)),
+				stroke=colors::Black,
+				color=status.type.color);
+		}
+
+		BaseGuiElement::draw();
+	}
+};
+
+void updateStatusBoxes(IGuiElement@ parent, array<Status>& statuses, array<GuiStatusBox@>& boxes, Object@ fromObject = null) {
+	uint prevCnt = boxes.length, cnt = statuses.length;
+	for(uint i = cnt; i < prevCnt; ++i)
+		boxes[i].remove();
+	boxes.length = cnt;
+	for(uint i = 0; i < cnt; ++i) {
+		auto@ icon = boxes[i];
+		if(icon is null) {
+			@icon = GuiStatusBox(parent);
+			@boxes[i] = icon;
+		}
+		@icon.fromObject = fromObject;
+		icon.update(statuses[i]);
+	}
+}


### PR DESCRIPTION
This fixes a few bugs in the Ion Cannon's Entangled status effect InterdictMovement, which in vanilla tries to just subtract max acceleration (this is insufficient, as while a ship is interdicted it may gain or lose acceleration due to First buff buildings or Marenium planet upgrades). Instead, the mover component is told to add or subtract a stack of interdiction, and the Mover then handles the interdicting effects. This also improves the UX, your movement commands don't get cancelled while interdicted, and will resume as you ordered them once the effect ends.
The duration tooltip for Entangled and Control computer boost statuses has also been ported from CE. This fixes no bugs as such, but fills a gaping UI/UX hole in the case of long duration ion cannon effects, as vanilla doesn't communicate the remaining duration of what could be as many as 1500 seconds to the player who was attacked by the ion cannon. Since I went to the effort of making the solution generic enough to work with any status is applied with a duration, I've added it to the control computer boost status too (this is one just nice to have rather than essential). In order to avoid increasing the bandwidth demand too much, these durations are only synced when a status has a delta anyway and the status type is marked as should be showing the duration to the client. The client calculates forward from the last sync time instead of needing regular syncs. This does impose the slight restriction that we can't really use variable status durations together with this tooltip code, but there aren't any vanilla hooks that do this afaik.