### PR TITLE
ModEfficiencyDistanceToOrbital hook bugfix

### DIFF
--- a/OpenSR/scripts/definitions/generic_effects.as
+++ b/OpenSR/scripts/definitions/generic_effects.as
@@ -4509,7 +4509,7 @@ class ModEfficiencyDistanceToOrbital : GenericEffect {
 		UpdatedValue@ value;
 		data.retrieve(@value);
 
-		if(value.value > 0) {
+		if(value.value != 0) {
 			obj.modFleetEffectiveness(-value.value);
 			value.value = 0;
 		}


### PR DESCRIPTION
Fix bug where the ModEfficiencyDistanceToOrbital hook wouldn't undo its effect if it was currently applying negative efficiency on disabling